### PR TITLE
feat: Fix link insert and add link edit tooltip

### DIFF
--- a/components/kun/milkdown/Editor.vue
+++ b/components/kun/milkdown/Editor.vue
@@ -14,9 +14,11 @@ import { trailing } from '@milkdown/plugin-trailing'
 import { usePluginViewFactory } from '@prosemirror-adapter/vue'
 import { upload, uploadConfig } from '@milkdown/plugin-upload'
 import { kunUploader, kunUploadWidgetFactory } from './plugins/uploader'
+import { insertLinkPlugin } from './plugins/hyperlinkInsert'
 // KUN Visual Novel Custom tooltip
 import { tooltipFactory } from '@milkdown/plugin-tooltip'
 import Tooltip from './plugins/Tooltip.vue'
+import LinkUpdatePopup from './plugins/LinkUpdatePopup.vue'
 // Custom text size calculate
 import Size from './plugins/Size.vue'
 import { $prose } from '@milkdown/utils'
@@ -60,6 +62,7 @@ const valueMarkdown = computed(() => props.valueMarkdown)
 const isShowMenu = computed(() => props.isShowMenu)
 
 const tooltip = tooltipFactory('Text')
+const linkUpdatePopup = tooltipFactory('linkUpdate')
 const pluginViewFactory = usePluginViewFactory()
 const container = ref<HTMLElement | null>(null)
 const toolbar = ref<HTMLElement | null>(null)
@@ -112,9 +115,17 @@ const editorInfo = useEditor((root) =>
         }
       })
 
+      useTempEditStore().editorContext = ctx
+
       ctx.set(tooltip.key, {
         view: pluginViewFactory({
           component: Tooltip
+        })
+      })
+
+      ctx.set(linkUpdatePopup.key, {
+        view: pluginViewFactory({
+          component: LinkUpdatePopup
         })
       })
     })
@@ -127,7 +138,9 @@ const editorInfo = useEditor((root) =>
     .use(indent)
     .use(trailing)
     .use(tooltip)
+    .use(linkUpdatePopup)
     .use(upload)
+    .use(insertLinkPlugin)
     // Add custom plugin view, calculate markdown text size
     .use(
       $prose(

--- a/components/kun/milkdown/plugins/InsertLink.vue
+++ b/components/kun/milkdown/plugins/InsertLink.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+
+const props = defineProps<{
+  show: boolean
+}>()
+const emit = defineEmits<{
+  insert: [href: string, text: string],
+  cancel: []
+}>()
+const inputHref = ref('')
+const inputText = ref('')
+const exampleURL = useRuntimeConfig().public.KUN_GALGAME_URL
+
+watch(
+  () => props.show,
+  () => {
+    inputHref.value = ''
+    inputText.value = ''
+  }
+)
+
+const handleLinkInsert = () => {
+  const text = inputText.value.length == 0 ? inputHref.value : inputText.value
+  emit("insert", inputHref.value, text)
+}
+
+const handleCancelInsert = () => {
+  emit("cancel")
+}
+
+</script>
+<template>
+  <Teleport to="body">
+    <Transition name="insertLink">
+      <div
+        class="mask"
+        tabindex="0"
+        v-if="show"
+      >
+        <div class="dialog">
+          <div>
+            <h2>{{ $t('edit.link.title') }}</h2>
+          </div>
+          <hr />
+          <div class="input-wrapper">
+            <label for="LinkURLInput" class="label">
+              {{ $t("edit.link.URLLabel") }}:
+            </label>
+              <input 
+                id="LinkURLInput" 
+                type="url"
+                v-model="inputHref"
+                :placeholder="exampleURL"
+                class="input"
+              />
+          </div>
+          <div class="input-wrapper">
+            <label for="LinkTextInput" class="label">
+              {{ $t("edit.link.textLabel") }}:
+            </label>
+            <input id="LinkTextInput"
+              type="text"
+              v-model="inputText"
+              class="input"
+            />
+          </div>
+          <div class="button-group">
+            <button @click="handleLinkInsert" class="confirm-btn">
+              {{ $t("edit.link.confirmInsert") }}
+            </button>
+            <button @click="handleCancelInsert" class="cancel-btn">
+              {{ $t("edit.link.cancelInsert") }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+<style lang="scss" scoped>
+.mask {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--kungalgame-mask-color-0);
+  transition: opacity 0.3s ease;
+  color: var(--kungalgame-font-color-3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.dialog {
+  width: 600px;
+  height: 225px;
+  padding: 17px;
+  background-color: var(--kungalgame-white);
+  border: 1px solid var(--kungalgame-blue-2);
+  border-radius: 5px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
+  transition: all 0.3s ease;
+  display: flex;
+  flex-direction: column;
+}
+.label {
+  display: inline-block;
+  width: 150px;
+  margin: 8px 0;
+}
+.input-wrapper {
+  padding: 4px 0;
+  display: inline-flex;
+}
+.input {
+  flex-grow: 1;
+  background-color: var(--kungalgame-trans-white-9);
+  font-size: 17px;
+  border: 1px solid var(--kungalgame-blue-5);
+  border-radius: 5px;
+  color: var(--kungalgame-font-color-3);
+}
+.button-group {
+  display: flex;
+  flex-grow: 1;
+  align-items: flex-end;
+  justify-content: flex-end;
+  flex-direction: row;
+  button {
+    height: 32px;
+    width: 77px;
+    margin: 0 5px;
+    border-radius: 5px;
+    transition: all 0.2s;
+    color: var(--kungalgame-blue-5);
+    border: 1px solid var(--kungalgame-blue-5);
+    background-color: var(--kungalgame-trans-white-9);
+    &:hover {
+      color: var(--kungalgame-white);
+      background-color: var(--kungalgame-blue-5);
+    }
+  }
+}
+</style>

--- a/components/kun/milkdown/plugins/LinkInsertDialog.vue
+++ b/components/kun/milkdown/plugins/LinkInsertDialog.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-
 const props = defineProps<{
   show: boolean
 }>()
 const emit = defineEmits<{
-  insert: [href: string, text: string],
+  insert: [href: string, text: string]
   cancel: []
 }>()
 const inputHref = ref('')
@@ -20,14 +19,16 @@ watch(
 )
 
 const handleLinkInsert = () => {
+  if (inputHref.value.length == 0) {
+    return
+  }
   const text = inputText.value.length == 0 ? inputHref.value : inputText.value
-  emit("insert", inputHref.value, text)
+  emit('insert', inputHref.value, text)
 }
 
 const handleCancelInsert = () => {
-  emit("cancel")
+  emit('cancel')
 }
-
 </script>
 <template>
   <Teleport to="body">
@@ -36,6 +37,7 @@ const handleCancelInsert = () => {
         class="mask"
         tabindex="0"
         v-if="show"
+        @keydown.enter="handleLinkInsert"
       >
         <div class="dialog">
           <div>
@@ -44,21 +46,22 @@ const handleCancelInsert = () => {
           <hr />
           <div class="input-wrapper">
             <label for="LinkURLInput" class="label">
-              {{ $t("edit.link.URLLabel") }}:
+              {{ $t('edit.link.URLLabel') }}:
             </label>
-              <input 
-                id="LinkURLInput" 
-                type="url"
-                v-model="inputHref"
-                :placeholder="exampleURL"
-                class="input"
-              />
+            <input
+              id="LinkURLInput"
+              type="url"
+              v-model="inputHref"
+              :placeholder="exampleURL"
+              class="input"
+            />
           </div>
           <div class="input-wrapper">
             <label for="LinkTextInput" class="label">
-              {{ $t("edit.link.textLabel") }}:
+              {{ $t('edit.link.textLabel') }}:
             </label>
-            <input id="LinkTextInput"
+            <input
+              id="LinkTextInput"
               type="text"
               v-model="inputText"
               class="input"
@@ -66,10 +69,10 @@ const handleCancelInsert = () => {
           </div>
           <div class="button-group">
             <button @click="handleLinkInsert" class="confirm-btn">
-              {{ $t("edit.link.confirmInsert") }}
+              {{ $t('edit.link.confirmInsert') }}
             </button>
             <button @click="handleCancelInsert" class="cancel-btn">
-              {{ $t("edit.link.cancelInsert") }}
+              {{ $t('edit.link.cancelInsert') }}
             </button>
           </div>
         </div>

--- a/components/kun/milkdown/plugins/LinkUpdatePopup.vue
+++ b/components/kun/milkdown/plugins/LinkUpdatePopup.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { TooltipProvider } from '@milkdown/plugin-tooltip'
+import { linkSchema, updateLinkCommand } from '@milkdown/preset-commonmark'
+import { TextSelection } from '@milkdown/prose/state'
+import { callCommand } from '@milkdown/utils'
+import { useInstance } from '@milkdown/vue'
+import { usePluginViewContext } from '@prosemirror-adapter/vue'
+import type { VNodeRef } from 'vue'
+
+const { view, prevState } = usePluginViewContext()
+
+const linkUpdPopRef = ref<VNodeRef>()
+const linkHref = ref('')
+const hide = ref(true)
+
+let tooltipProvider: TooltipProvider
+
+onMounted(() => {
+  const ctx = useTempEditStore().$state.editorContext
+
+  if (!ctx) {
+    // Maybe throw a error?
+    return
+  }
+  tooltipProvider = new TooltipProvider({
+    content: linkUpdPopRef.value as any,
+    debounce: 50,
+    shouldShow: (view, prevState) => {
+      if (!view.hasFocus() || !view.editable) {
+        return false
+      }
+      const { selection, doc } = view.state
+      const { from, to } = selection
+
+      const linkMarkType = linkSchema.type(ctx)
+      if (
+        selection instanceof TextSelection &&
+        to < doc.content.size &&
+        from < doc.content.size &&
+        doc.rangeHasMark(from, from === to ? to + 1 : to, linkMarkType)
+      ) {
+        const cursor = selection.$cursor
+        if (!cursor) {
+          return false
+        }
+        const linkMark = doc
+          .nodeAt(selection.$cursor.pos)
+          ?.marks.find((mark) => mark.type == linkMarkType)
+        if (!linkMark) {
+          return false
+        }
+        linkHref.value = linkMark.attrs.href
+        hide.value = false
+        return selection.empty
+      }
+      return false
+    }
+  })
+
+  tooltipProvider.update(view.value, prevState.value)
+})
+
+watch([view, prevState], () => {
+  tooltipProvider?.update(view.value, prevState.value)
+})
+
+onUnmounted(() => {
+  tooltipProvider.destroy()
+})
+
+const handleUpdateLink = () => {
+  const get = useInstance()[1]
+  get()?.action(callCommand(updateLinkCommand.key, { href: linkHref.value }))
+}
+</script>
+
+<template>
+  <div ref="linkUpdPopRef">
+    <div v-if="!hide" class="wrapper">
+      <input 
+        class="input" 
+        type="url"
+        @keydown.enter = "handleUpdateLink"
+        v-model="linkHref" 
+      />
+      <button class="confirm-btn" @click="handleUpdateLink">
+        {{ $t('edit.link.confirmUpdate') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.wrapper {
+  width: 350px;
+  min-height: 47px;
+  display: inline-flex;
+  border: 1px solid var(--kungalgame-blue-5);
+  border-radius: 5px;
+  background-color: var(--kungalgame-trans-white-2);
+}
+.input {
+  flex-grow: 1;
+  border: none;
+  margin: 4px 8px;
+}
+.confirm-btn {
+  width: 65px;
+  background-color: transparent;
+  border: none;
+  color: var(--kungalgame-blue-5);
+  font-size: 15px;
+  padding: 0 4px;
+  &:hover {
+    color: var(--kungalgame-white);
+    background-color: var(--kungalgame-blue-5);
+  }
+}
+</style>

--- a/components/kun/milkdown/plugins/Menu.vue
+++ b/components/kun/milkdown/plugins/Menu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { callCommand } from '@milkdown/utils'
+import { insert, callCommand } from '@milkdown/utils'
 import {
   createCodeBlockCommand,
   updateCodeBlockLanguageCommand,
@@ -23,9 +23,15 @@ const props = defineProps<{
 
 const { get, loading } = props.editorInfo
 const input = ref<HTMLElement>()
+const isShowInsertLink = ref(false)
 
 const call = <T,>(command: CmdKey<T>, payload?: T) => {
   return get()?.action(callCommand(command, payload))
+}
+
+const handelInsertLink = (href: string, text: string) => {
+  get()?.action(insert(`[${text}](${href})`))
+  isShowInsertLink.value = false
 }
 
 // Select a language TODO:
@@ -122,8 +128,13 @@ const handleClickUploadImage = () => {
       <Icon name="lucide:minus" />
     </div>
 
-    <div aria-label="kun-galgame-italic" @click="call(toggleLinkCommand.key)">
+    <div aria-label="kun-galgame-italic" @click="isShowInsertLink=true">
       <Icon name="lucide:link" />
+      <KunMilkdownPluginsInsertLink 
+        :show="isShowInsertLink"
+        @insert="handelInsertLink"
+        @cancel="isShowInsertLink = false"
+      />
     </div>
 
     <div aria-label="kun-galgame-italic" @click="handleClickCodeBlock">

--- a/components/kun/milkdown/plugins/Menu.vue
+++ b/components/kun/milkdown/plugins/Menu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { insert, callCommand } from '@milkdown/utils'
+import { callCommand } from '@milkdown/utils'
 import {
   createCodeBlockCommand,
   updateCodeBlockLanguageCommand,
@@ -16,6 +16,7 @@ import {
 import { toggleStrikethroughCommand } from '@milkdown/preset-gfm'
 import type { UseEditorReturn } from '@milkdown/vue'
 import type { CmdKey } from '@milkdown/core'
+import { insertLinkPlugin } from './hyperlinkInsert'
 
 const props = defineProps<{
   editorInfo: UseEditorReturn
@@ -30,7 +31,7 @@ const call = <T,>(command: CmdKey<T>, payload?: T) => {
 }
 
 const handelInsertLink = (href: string, text: string) => {
-  get()?.action(insert(`[${text}](${href})`))
+  call(insertLinkPlugin.key, { href, text })
   isShowInsertLink.value = false
 }
 
@@ -128,9 +129,9 @@ const handleClickUploadImage = () => {
       <Icon name="lucide:minus" />
     </div>
 
-    <div aria-label="kun-galgame-italic" @click="isShowInsertLink=true">
+    <div aria-label="kun-galgame-italic" @click="isShowInsertLink = true">
       <Icon name="lucide:link" />
-      <KunMilkdownPluginsInsertLink 
+      <KunMilkdownPluginsLinkInsertDialog
         :show="isShowInsertLink"
         @insert="handelInsertLink"
         @cancel="isShowInsertLink = false"

--- a/components/kun/milkdown/plugins/hyperlinkInsert.ts
+++ b/components/kun/milkdown/plugins/hyperlinkInsert.ts
@@ -1,0 +1,21 @@
+import { linkSchema } from '@milkdown/preset-commonmark'
+import { $command } from '@milkdown/utils'
+
+export const insertLinkPlugin = $command(
+  'InsertLink',
+  (ctx) =>
+    (payload: { href: string; text: string } | undefined) =>
+    (state, dispatch?) => {
+      if (!dispatch || !payload) return false
+      const transaction = state.tr
+      const linkMark = linkSchema.type(ctx).create({ href: payload.href })
+      dispatch(
+        transaction
+          .addStoredMark(linkMark)
+          .insertText(payload.text)
+          .removeStoredMark(linkMark)
+          .scrollIntoView()
+      )
+      return true
+    }
+)

--- a/components/kun/milkdown/plugins/hyperlinkUpdate.ts
+++ b/components/kun/milkdown/plugins/hyperlinkUpdate.ts
@@ -1,0 +1,21 @@
+import type { EditorView } from '@milkdown/prose/view'
+import type { Node } from '@milkdown/prose/model'
+import { linkSchema } from '@milkdown/preset-commonmark'
+import type { Ctx } from '@milkdown/ctx'
+
+export const handleClickOn = (
+  ctx: Ctx,
+  view: EditorView,
+  pos: number,
+  node: Node /*, nodePos: number, event: MouseEvent, direct: boolean*/
+) => {
+  if (!node.isLeaf) {
+    return false
+  }
+  const linkType = linkSchema.type(ctx)
+  if (!node.marks.find((mark) => mark.type == linkType)) {
+    return false
+  }
+
+  return true
+}

--- a/language/en.json
+++ b/language/en.json
@@ -266,7 +266,8 @@
       "URLLabel": "Link URL",
       "textLabel": "Link Text(Optional)",
       "confirmInsert": "Confirm",
-      "cancelInsert": "Cancel"
+      "cancelInsert": "Cancel",
+      "confirmUpdate": "Update"
     },
     "publish": "Confirm Publish",
     "rewrite": "Confirm Rewrite"

--- a/language/en.json
+++ b/language/en.json
@@ -261,6 +261,13 @@
       "o-novel": "Light Novel",
       "o-other": "Other"
     },
+    "link": {
+      "title": "Insert Hyperlink",
+      "URLLabel": "Link URL",
+      "textLabel": "Link Text(Optional)",
+      "confirmInsert": "Confirm",
+      "cancelInsert": "Cancel"
+    },
     "publish": "Confirm Publish",
     "rewrite": "Confirm Rewrite"
   },

--- a/language/zh-CN.json
+++ b/language/zh-CN.json
@@ -263,6 +263,13 @@
       "o-novel": "轻小说",
       "o-other": "其它"
     },
+    "link": {
+      "title": "插入超链接",
+      "URLLabel": "链接URL",
+      "textLabel": "链接文字（可选）",
+      "confirmInsert": "插入",
+      "cancelInsert": "取消"
+    },
     "publish": "确认发布",
     "rewrite": "确认 Rewrite"
   },

--- a/language/zh-CN.json
+++ b/language/zh-CN.json
@@ -268,7 +268,8 @@
       "URLLabel": "链接URL",
       "textLabel": "链接文字（可选）",
       "confirmInsert": "插入",
-      "cancelInsert": "取消"
+      "cancelInsert": "取消",
+      "confirmUpdate": "更改"
     },
     "publish": "确认发布",
     "rewrite": "确认 Rewrite"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kun-galgame-nuxt3",
-  "version": "2.7.23",
+  "version": "2.7.24",
   "private": true,
   "scripts": {
     "build": "nuxt build",

--- a/store/temp/edit.ts
+++ b/store/temp/edit.ts
@@ -1,3 +1,4 @@
+import type { Ctx } from '@milkdown/ctx'
 import type { EditStoreTemp } from '~/store/types/edit'
 
 export const useTempEditStore = defineStore({
@@ -14,7 +15,9 @@ export const useTempEditStore = defineStore({
     textCount: 0,
     isTopicRewriting: false,
 
-    autosaveCount: 0
+    autosaveCount: 0,
+
+    editorContext: shallowRef<Ctx | null>(null)
   }),
   actions: {
     resetRewriteTopicData() {

--- a/store/types/edit.d.ts
+++ b/store/types/edit.d.ts
@@ -1,3 +1,6 @@
+import type { Ctx } from '@milkdown/ctx'
+import type { ShallowRef } from 'vue'
+
 export interface EditStorePersist {
   editorHeight: number
   textCount: number
@@ -23,4 +26,6 @@ export interface EditStoreTemp {
   isTopicRewriting: boolean
 
   autosaveCount: number
+
+  editorContext: ShallowRef<Ctx | null>
 }


### PR DESCRIPTION
This patch mainly add two functions: link insert and link edit in Milkdown editor.

## Link Insert
Even though Milkdown's official example use "togglelink" instead of insert link in its menu bar, I reckon that most common user who is not familar with markdown can get confused by this design and will prefer a more direct "link insert" buttion. 

This function is supported through a Milkdown composed command plugin, which add an "insertlink" command. And the UI is designed as a dialog which ask user for a link and optional text(default the same with href). The "title" field is ignored but anyway its almost useless?

As the input url is not checked, I do wonder if there exist a XSS issue; but this dialog should be logically equal to a `[]()` input.

What's more, this patch can also illustrate that `<Teleport>` can function correctly even without `:disable`.

Preview:
<img width="781" alt="屏幕截图 2024-03-26 145500" src="https://github.com/KUN1007/kun-galgame-nuxt3/assets/164053856/37f87700-d5d9-4993-8519-8bf9abbc86b2">

## Link Update
The idea comes from the Milkdown official example: when you clicked at a link, it should popup a tooltip and the user can edit the href of the link. However, as KUN has pointed out, all those functions are removed in v6 and are left for devs to build their own ones.

As a result, I rewrite this function under Milkdown v7 as a tooltip, referring to the implementations in v6 as a link mark plugin. However, due to the limitations in prosemirror vue adaptor, it just cannot pass the ctx into vue component during initialization, so I have to make use of pinia to pass the ctx into the tooltip vue component. (By the way the vue component is not a sub-component of Editor component, so even provide-inject will not work here).

The `hide` property in the component is used as an more elegant altenative to `v-if="loading"`, as v-if=false will cause the whole component fail to response to ref change(The reactivity on linkHref will not work anymore).

Preview:
<img width="361" alt="屏幕截图 2024-03-26 145528" src="https://github.com/KUN1007/kun-galgame-nuxt3/assets/164053856/aed02862-8255-471c-93b4-01d1b7e754d4">

## Misc
A `npm run format` is run before the commits.

As components in this patch are poorly named and pinia file is modified, a code review might be necessary.