### PR TITLE
fix: unify user navigation touchpad and mouse interaction focus

### DIFF
--- a/components/kun/top-bar/UserInfo.vue
+++ b/components/kun/top-bar/UserInfo.vue
@@ -25,6 +25,10 @@ const handlePanelBlur = async () => {
   emits('close')
 }
 
+const handleMouseDown = (event: MouseEvent | TouchEvent) => {
+  container.value?.focus() // 重新聚焦
+}
+
 const handleCheckIn = async () => {
   isCheckIn.value = true
 
@@ -76,7 +80,14 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div ref="container" tabindex="-1" class="container" @blur="handlePanelBlur">
+  <div
+    ref="container"
+    tabindex="-1"
+    class="container"
+    @blur="handlePanelBlur"
+    @mousedown.prevent="handleMouseDown"
+    @touchstart.prevent="handleMouseDown"
+  >
     <span class="triangle1"></span>
     <span class="triangle2"></span>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kun-galgame-nuxt3",
-  "version": "2.18.15",
+  "version": "2.18.16",
   "private": true,
   "scripts": {
     "build": "nuxt build",


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #82 

## Note / 说明

在 `@mousedown` 和 `@touchstart` 事件处理器中手动调用 `focus()` 方法，以统一触摸板与鼠标交互