### PR TITLE
fix(milkdown): add max height to Codemirror editor to enable scrolling

### DIFF
--- a/apps/web/app/components/kun/milkdown/codemirror/Codemirror.vue
+++ b/apps/web/app/components/kun/milkdown/codemirror/Codemirror.vue
@@ -57,6 +57,6 @@ watch(
 <template>
   <div
     ref="editorDiv"
-    class="scrollbar-hide flex-1 overflow-y-scroll overscroll-x-none"
+    class="scrollbar-hide flex-1 overflow-y-scroll overscroll-none"
   />
 </template>

--- a/apps/web/app/components/kun/milkdown/codemirror/Codemirror.vue
+++ b/apps/web/app/components/kun/milkdown/codemirror/Codemirror.vue
@@ -57,6 +57,6 @@ watch(
 <template>
   <div
     ref="editorDiv"
-    class="scrollbar-hide flex-1 overflow-y-scroll overscroll-none"
+    class="scrollbar-hide flex-1 overflow-y-scroll overscroll-none max-h-[500px]"
   />
 </template>

--- a/apps/web/app/components/kun/milkdown/codemirror/Codemirror.vue
+++ b/apps/web/app/components/kun/milkdown/codemirror/Codemirror.vue
@@ -57,6 +57,6 @@ watch(
 <template>
   <div
     ref="editorDiv"
-    class="scrollbar-hide flex-1 overflow-y-scroll overscroll-none"
+    class="scrollbar-hide flex-1 overflow-y-scroll overscroll-x-none"
   />
 </template>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kun-galgame-nuxt4-fiber",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "private": true,
   "packageManager": "pnpm@10.12.1",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kun-galgame-nuxt4-fiber",
-  "version": "5.1.5",
+  "version": "5.1.4",
   "private": true,
   "packageManager": "pnpm@10.12.1",
   "workspaces": [


### PR DESCRIPTION
问题:  
在话题发布界面的 "MD代码" 编辑器界面中, 当鼠标悬停在编辑器输入界面的时候无法垂直滚动

解决:  
为 `Codemirror.vue` 组件添加最大高度限制
