### PR TITLE
fix(search): pass active tab type directly to searchQuery on tab switch

### DIFF
--- a/apps/web/app/components/search/Container.vue
+++ b/apps/web/app/components/search/Container.vue
@@ -26,11 +26,15 @@ const isLoadComplete = computed(
   () => total.value > 0 && results.value.length >= total.value
 )
 
-const searchQuery = async (): Promise<SearchPage> => {
+const searchQuery = async (searchType?: string): Promise<SearchPage> => {
   isLoading.value = true
   const result = await kunFetch<SearchPage>('/search', {
     method: 'GET',
-    query: { keywords: keywords.value, type: activeType.value, ...pageData }
+    query: {
+      keywords: keywords.value,
+      type: searchType || activeType.value,
+      ...pageData
+    }
   })
   isLoading.value = false
   return result ?? { items: [], total: 0 }
@@ -43,7 +47,7 @@ const handleSetType = async (value: SearchType) => {
   total.value = 0
 
   if (keywords.value) {
-    const page = await searchQuery()
+    const page = await searchQuery(value)
     results.value = page.items
     total.value = page.total
   } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kun-galgame-forum",
-  "version": "6.1.42",
+  "version": "6.1.44",
   "private": true,
   "packageManager": "pnpm@10.12.1",
   "workspaces": [


### PR DESCRIPTION
目前，搜索页存在一个bug，例如在“话题”模式下输入“a”进行搜索，在搜索完成后切换模式为“Galgame”，会出现空结果，且console中出现报错。

这是因为`activeType`数据的更新没有那么及时，一个简单的修复方案就是在`searchQuery`中增加`searchType`参数来强制覆盖最新的`type`。