### PR TITLE
fix:Fixed the issue where multi-tag search couldn't do partial matches (#136)

### DIFF
--- a/apps/api/internal/app/router.go
+++ b/apps/api/internal/app/router.go
@@ -209,6 +209,7 @@ func (a *App) setupRoutes() {
 	api.Get("/galgame-tag", a.GalgameEntityHandler.GetTagList)
 	api.Get("/galgame-tag/search", a.GalgameEntityHandler.SearchTags)
 	api.Get("/galgame-tag/multi", a.GalgameEntityHandler.GetMultiTagGalgames)
+	api.Get("/galgame-tag/multi-contains", a.GalgameEntityHandler.GetMultiTagGalgamesContains)
 	api.Get("/galgame-tag/:name", a.GalgameEntityHandler.GetTagDetail)
 	api.Get("/galgame-official", a.GalgameEntityHandler.GetOfficialList)
 	api.Get("/galgame-official/search", a.GalgameEntityHandler.SearchOfficials)

--- a/apps/api/internal/galgame/handler/entity_handler.go
+++ b/apps/api/internal/galgame/handler/entity_handler.go
@@ -1,10 +1,12 @@
-package handler
+﻿package handler
 
 import (
 	"net/url"
+	"strconv"
 
 	"kun-galgame-api/internal/galgame/dto"
 	"kun-galgame-api/internal/galgame/service"
+	"kun-galgame-api/pkg/errors"
 	"kun-galgame-api/pkg/response"
 	"kun-galgame-api/pkg/utils"
 
@@ -154,6 +156,28 @@ func (h *EntityHandler) GetMultiTagGalgames(c fiber.Ctx) error {
 	return response.OK(c, page)
 }
 
+// GetMultiTagGalgamesContains — GET /galgame-tag/multi-contains
+//
+// Contains-mode multi-tag endpoint. Accepts comma-separated human-readable
+// tag names (not numeric IDs), splits each into CJK characters, expands via
+// substring matching, computes the Cartesian product, and returns the
+// deduplicated + paginated union of all combination results.
+func (h *EntityHandler) GetMultiTagGalgamesContains(c fiber.Ctx) error {
+	tagNamesStr := c.Query("tagNames")
+	if tagNamesStr == "" {
+		return response.Error(c, errors.ErrBadRequest("缺少 tagNames 参数"))
+	}
+	page := atoiOr(c.Query("page"), 1)
+	limit := atoiOr(c.Query("limit"), 24)
+	result, appErr := h.tagService.GetByMultiTagContains(
+		c.Context(), tagNamesStr, utils.IsSFW(c), page, limit,
+	)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	return response.OK(c, result)
+}
+
 // GetTagDetail — GET /galgame-tag/:name
 func (h *EntityHandler) GetTagDetail(c fiber.Ctx) error {
 	detail, appErr := h.tagService.GetDetail(
@@ -179,4 +203,16 @@ func collectQuery(c fiber.Ctx) url.Values {
 		q.Set(k, v)
 	}
 	return q
+}
+
+// atoiOr parses s as an int or returns def on failure / zero / negative.
+func atoiOr(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil || v <= 0 {
+		return def
+	}
+	return v
 }

--- a/apps/api/internal/galgame/service/tag_service.go
+++ b/apps/api/internal/galgame/service/tag_service.go
@@ -1,9 +1,13 @@
-package service
+﻿package service
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
+	"sort"
+	"strings"
+	"strconv"
 
 	"kun-galgame-api/internal/galgame/client"
 	"kun-galgame-api/internal/galgame/dto"
@@ -57,28 +61,91 @@ func (s *TagService) Search(
 	rawQuery url.Values,
 	isSFW bool,
 ) ([]dto.TagListItem, *errors.AppError) {
+	searchQuery := rawQuery.Get("q")
+
+	// Try Meilisearch first.
 	data, appErr := s.galgameClient.GetV1(ctx, "/galgame/tags/search", withSFWFilter(rawQuery, isSFW))
-	if appErr != nil {
+	if appErr == nil {
+		var resp struct {
+			Items []nextMoeTagListItem `json:"items"`
+		}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return nil, errors.ErrInternal("解析 Galgame 响应失败")
+		}
+		items := make([]dto.TagListItem, 0, len(resp.Items))
+		for _, t := range resp.Items {
+			if isSFW && t.Category == "sexual" {
+				continue
+			}
+			items = append(items, dto.TagListItem{
+				ID: t.ID, Name: t.Name, Category: t.Category,
+				GalgameCount: t.GalgameCount,
+			})
+		}
+		return items, nil
+	}
+
+	// Meilisearch unavailable — fall back to client-side substring search.
+	if searchQuery == "" {
 		return nil, appErr
 	}
-	var resp struct {
-		Items []nextMoeTagListItem `json:"items"`
-	}
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, errors.ErrInternal("解析 Galgame 响应失败")
-	}
-	items := make([]dto.TagListItem, 0, len(resp.Items))
-	for _, t := range resp.Items {
-		if isSFW && t.Category == "sexual" {
-			continue
-		}
-		items = append(items, dto.TagListItem{
-			ID: t.ID, Name: t.Name, Category: t.Category,
-			GalgameCount: t.GalgameCount,
-		})
-	}
-	return items, nil
+	return s.searchContains(ctx, searchQuery, isSFW)
 }
+
+// searchContains fetches all tags (paginated) and returns those whose Name
+// contains the query as a substring. Used as a fallback when Meilisearch is
+// unavailable in dev.
+func (s *TagService) searchContains(
+	ctx context.Context,
+	query string,
+	isSFW bool,
+) ([]dto.TagListItem, *errors.AppError) {
+	const maxPages = 5
+	const perPage = 200
+	seen := make(map[int]bool)
+	var result []dto.TagListItem
+
+	queryLower := strings.ToLower(query)
+
+	for page := 1; page <= maxPages; page++ {
+		q := url.Values{
+			"page":  {strconv.Itoa(page)},
+			"limit": {strconv.Itoa(perPage)},
+		}
+		if isSFW {
+			q.Set("content_limit", "sfw")
+		}
+		data, appErr := s.galgameClient.GetV1(ctx, "/galgame/tags", q)
+		if appErr != nil {
+			return nil, appErr
+		}
+		var parsed nextMoeTagListResp
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			return nil, errors.ErrInternal("解析 Galgame 响应失败")
+		}
+		if len(parsed.Items) == 0 {
+			break
+		}
+		for _, t := range parsed.Items {
+			if seen[t.ID] {
+				continue
+			}
+			if isSFW && t.Category == "sexual" {
+				continue
+			}
+			if strings.Contains(strings.ToLower(t.Name), queryLower) {
+				seen[t.ID] = true
+				result = append(result, dto.TagListItem{
+					ID: t.ID, Name: t.Name, Category: t.Category,
+					GalgameCount: t.GalgameCount,
+				})
+			}
+		}
+	}
+
+	return result, nil
+}
+
 
 // GetByMultiTag — GET /galgame-tag/multi
 //
@@ -123,6 +190,166 @@ func (s *TagService) GetByMultiTag(
 	return &TagMultiPage{
 		Galgames: s.enricher.ToCards(ctx, filtered),
 		Total:    parsed.Total,
+	}, nil
+}
+
+// cartesianProduct computes the cartesian product of a slice of slices.
+// Example: [[1,2], [3]] → [[1,3], [2,3]]
+func cartesianProduct(sets [][]int) [][]int {
+	if len(sets) == 0 {
+		return nil
+	}
+	result := [][]int{{}}
+	for _, set := range sets {
+		var next [][]int
+		for _, existing := range result {
+			for _, id := range set {
+				combo := make([]int, len(existing)+1)
+				copy(combo, existing)
+				combo[len(existing)] = id
+				next = append(next, combo)
+			}
+		}
+		result = next
+	}
+	return result
+}
+
+// GetByMultiTagContains is the public entry point for
+// GET /galgame-tag/multi-contains. It accepts comma-separated human-readable
+// tag names (not numeric IDs), splits each into CJK characters, expands every
+// character to matching tag IDs via substring matching, computes the Cartesian
+// product, queries each combination, and returns the deduplicated + paginated
+// union.
+func (s *TagService) GetByMultiTagContains(
+	ctx context.Context,
+	tagNamesStr string,
+	isSFW bool,
+	page, limit int,
+) (*TagMultiPage, *errors.AppError) {
+	if tagNamesStr == "" {
+		return &TagMultiPage{Galgames: nil, Total: 0}, nil
+	}
+	tagNames := make([]string, 0)
+	for _, part := range strings.Split(tagNamesStr, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			tagNames = append(tagNames, part)
+		}
+	}
+	if len(tagNames) == 0 {
+		return &TagMultiPage{Galgames: nil, Total: 0}, nil
+	}
+	// 1. Expand each tag name to matching tag IDs via Meilisearch.
+	//    Meilisearch natively tokenises CJK text, so a single call per
+	//    name (e.g. "硬科幻") matches tags containing any of its characters
+	//    without a separate client-side split step.
+	expansion := make([][]int, len(tagNames))
+	for i, name := range tagNames {
+		items, appErr := s.Search(ctx, url.Values{"q": {name}}, isSFW)
+		if appErr != nil {
+			return nil, appErr
+		}
+		if len(items) == 0 {
+			return &TagMultiPage{Galgames: nil, Total: 0}, nil
+		}
+		ids := make([]int, len(items))
+		for j, item := range items {
+			ids[j] = item.ID
+		}
+		expansion[i] = ids
+	}
+
+	// 2. Cartesian product → query each combo via /galgame/tags/multi →
+	//    deduplicate → paginate.
+	return s.executeCartesianUnion(ctx, expansion, isSFW, page, limit)
+}
+
+// executeCartesianUnion caps each expansion group, computes the Cartesian
+// product, queries each combination via /galgame/tags/multi (AND within each
+// combo), and returns the deduplicated + paginated union over all combos.
+func (s *TagService) executeCartesianUnion(
+	ctx context.Context,
+	expansion [][]int,
+	isSFW bool,
+	page, limit int,
+) (*TagMultiPage, *errors.AppError) {
+	//暂时不限流
+	// const maxExpansion = 50
+	// for i := range expansion {
+	// 	if len(expansion[i]) > maxExpansion {
+	// 		expansion[i] = expansion[i][:maxExpansion]
+	// 	}
+	// }
+	combos := cartesianProduct(expansion)
+	type indexedCard struct {
+		card  dto.GalgameCard
+		order int
+	}
+	seen := make(map[int]indexedCard)
+	comboOrder := 0
+	for _, combo := range combos {
+		idsStr := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(combo)), ","), "[]")
+		q := url.Values{
+			"ids":     {idsStr},
+			"include": {"meta"},
+		}
+		if isSFW {
+			q.Set("content_limit", "sfw")
+		}
+		data, appErr := s.galgameClient.GetV1(ctx, "/galgame/tags/multi", q)
+		if appErr != nil {
+			comboOrder++
+			continue
+		}
+		var parsed struct {
+			Items []client.V1Item `json:"items"`
+			Total int64           `json:"total"`
+		}
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			comboOrder++
+			continue
+		}
+		items := make([]dto.NextMoeGalgameItem, 0, len(parsed.Items))
+		for j := range parsed.Items {
+			items = append(items, client.V1ItemToNextMoeItem(&parsed.Items[j]))
+		}
+		filtered := s.enricher.FilterSFW(items, isSFW)
+		cards := s.enricher.ToCards(ctx, filtered)
+		for _, card := range cards {
+			if _, exists := seen[card.ID]; !exists {
+				seen[card.ID] = indexedCard{card: card, order: comboOrder}
+			}
+		}
+		comboOrder++
+	}
+	type entry struct {
+		card  dto.GalgameCard
+		order int
+	}
+	entries := make([]entry, 0, len(seen))
+	for _, v := range seen {
+		entries = append(entries, entry{card: v.card, order: v.order})
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].order < entries[j].order
+	})
+	allCards := make([]dto.GalgameCard, 0, len(entries))
+	for _, e := range entries {
+		allCards = append(allCards, e.card)
+	}
+	total := int64(len(allCards))
+	start := (page - 1) * limit
+	if start >= int(len(allCards)) {
+		return &TagMultiPage{Galgames: nil, Total: total}, nil
+	}
+	end := start + limit
+	if end > len(allCards) {
+		end = len(allCards)
+	}
+	return &TagMultiPage{
+		Galgames: allCards[start:end],
+		Total:    total,
 	}, nil
 }
 

--- a/apps/api/internal/galgame/service/tag_service.go
+++ b/apps/api/internal/galgame/service/tag_service.go
@@ -7,8 +7,6 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"strconv"
-
 	"kun-galgame-api/internal/galgame/client"
 	"kun-galgame-api/internal/galgame/dto"
 	"kun-galgame-api/pkg/errors"
@@ -61,91 +59,28 @@ func (s *TagService) Search(
 	rawQuery url.Values,
 	isSFW bool,
 ) ([]dto.TagListItem, *errors.AppError) {
-	searchQuery := rawQuery.Get("q")
-
-	// Try Meilisearch first.
 	data, appErr := s.galgameClient.GetV1(ctx, "/galgame/tags/search", withSFWFilter(rawQuery, isSFW))
-	if appErr == nil {
-		var resp struct {
-			Items []nextMoeTagListItem `json:"items"`
-		}
-		if err := json.Unmarshal(data, &resp); err != nil {
-			return nil, errors.ErrInternal("解析 Galgame 响应失败")
-		}
-		items := make([]dto.TagListItem, 0, len(resp.Items))
-		for _, t := range resp.Items {
-			if isSFW && t.Category == "sexual" {
-				continue
-			}
-			items = append(items, dto.TagListItem{
-				ID: t.ID, Name: t.Name, Category: t.Category,
-				GalgameCount: t.GalgameCount,
-			})
-		}
-		return items, nil
-	}
-
-	// Meilisearch unavailable — fall back to client-side substring search.
-	if searchQuery == "" {
+	if appErr != nil {
 		return nil, appErr
 	}
-	return s.searchContains(ctx, searchQuery, isSFW)
-}
-
-// searchContains fetches all tags (paginated) and returns those whose Name
-// contains the query as a substring. Used as a fallback when Meilisearch is
-// unavailable in dev.
-func (s *TagService) searchContains(
-	ctx context.Context,
-	query string,
-	isSFW bool,
-) ([]dto.TagListItem, *errors.AppError) {
-	const maxPages = 5
-	const perPage = 200
-	seen := make(map[int]bool)
-	var result []dto.TagListItem
-
-	queryLower := strings.ToLower(query)
-
-	for page := 1; page <= maxPages; page++ {
-		q := url.Values{
-			"page":  {strconv.Itoa(page)},
-			"limit": {strconv.Itoa(perPage)},
-		}
-		if isSFW {
-			q.Set("content_limit", "sfw")
-		}
-		data, appErr := s.galgameClient.GetV1(ctx, "/galgame/tags", q)
-		if appErr != nil {
-			return nil, appErr
-		}
-		var parsed nextMoeTagListResp
-		if err := json.Unmarshal(data, &parsed); err != nil {
-			return nil, errors.ErrInternal("解析 Galgame 响应失败")
-		}
-		if len(parsed.Items) == 0 {
-			break
-		}
-		for _, t := range parsed.Items {
-			if seen[t.ID] {
-				continue
-			}
-			if isSFW && t.Category == "sexual" {
-				continue
-			}
-			if strings.Contains(strings.ToLower(t.Name), queryLower) {
-				seen[t.ID] = true
-				result = append(result, dto.TagListItem{
-					ID: t.ID, Name: t.Name, Category: t.Category,
-					GalgameCount: t.GalgameCount,
-				})
-			}
-		}
+	var resp struct {
+		Items []nextMoeTagListItem `json:"items"`
 	}
-
-	return result, nil
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, errors.ErrInternal("解析 Galgame 响应失败")
+	}
+	items := make([]dto.TagListItem, 0, len(resp.Items))
+	for _, t := range resp.Items {
+		if isSFW && t.Category == "sexual" {
+			continue
+		}
+		items = append(items, dto.TagListItem{
+			ID: t.ID, Name: t.Name, Category: t.Category,
+			GalgameCount: t.GalgameCount,
+		})
+	}
+	return items, nil
 }
-
 
 // GetByMultiTag — GET /galgame-tag/multi
 //

--- a/apps/web/app/components/galgame/tag/Container.vue
+++ b/apps/web/app/components/galgame/tag/Container.vue
@@ -33,9 +33,9 @@ const matchModeOptions = [
 const displayTags = computed(() => {
   if (searchMode.value === 'single') {
     if (searchQuery.value.trim()) return searchResult.value
-    return data.value?.tags ?? []
+    return data.value!.tags
   }
-  return data.value?.tags ?? []
+  return data.value!.tags
 })
 
 // True when we're showing the FULL paginated tag list (the BE returns the

--- a/apps/web/app/components/galgame/tag/Container.vue
+++ b/apps/web/app/components/galgame/tag/Container.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+﻿<script setup lang="ts">
 import { watchDebounced } from '@vueuse/core'
 
 const pageData = reactive({
@@ -24,12 +24,18 @@ const searchModeOptions = [
   { label: '多标签搜索', value: 'multi' }
 ] as const
 
+const matchMode = ref<'exact' | 'contains'>('exact')
+const matchModeOptions = [
+  { label: '精确模式', value: 'exact' },
+  { label: '包含模式', value: 'contains' }
+] as const
+
 const displayTags = computed(() => {
   if (searchMode.value === 'single') {
     if (searchQuery.value.trim()) return searchResult.value
-    return data.value!.tags
+    return data.value?.tags ?? []
   }
-  return data.value!.tags
+  return data.value?.tags ?? []
 })
 
 // True when we're showing the FULL paginated tag list (the BE returns the
@@ -94,17 +100,37 @@ const fetchGames = async () => {
     return
   }
   loadingGames.value = true
-  const res = await kunFetch<{ galgames: GalgameCard[]; total: number }>(
-    `/galgame-tag/multi`,
-    {
-      method: 'GET',
-      query: {
-        page: gamesPage.value,
-        limit: gamesLimit,
-        tagIds: selectedTags.value.map((t) => t.id).join(',')
+
+  let res: { galgames: GalgameCard[]; total: number } | null = null
+
+  //Add contains mode
+  if (matchMode.value === 'contains') {
+    res = await kunFetch<{ galgames: GalgameCard[]; total: number }>(
+      '/galgame-tag/multi-contains',
+      {
+        method: 'GET',
+        query: {
+          page: gamesPage.value,
+          limit: gamesLimit,
+          tagNames:selectedTags.value.map((t) => t.name).join(',')
+        }
       }
-    }
-  )
+    )
+  } else {
+    //default mode
+    res = await kunFetch<{ galgames: GalgameCard[]; total: number }>(
+      `/galgame-tag/multi`,
+      {
+        method: 'GET',
+        query: {
+          page: gamesPage.value,
+          limit: gamesLimit,
+          tagIds: selectedTags.value.map((t) => t.id).join(',')
+        }
+      }
+    )
+  }
+
   loadingGames.value = false
   if (res) {
     resultGames.value = res.galgames
@@ -174,6 +200,14 @@ watch(
               v-model="searchMode"
               :options="searchModeOptions"
               aria-label="search-mode"
+              class-name="w-36"
+            />
+
+            <KunSelect
+              v-if="searchMode === 'multi'"
+              v-model="matchMode"
+              :options="matchModeOptions"
+              aria-label="match-mode"
               class-name="w-36"
             />
 


### PR DESCRIPTION

## PR: fix: 多标签搜索支持包含模式（partial match）

Issue: #136

## 问题描述

当前多标签搜索仅支持**精确匹配**。当用户选择「后宫结局 + 科幻」时，只能查询到同时拥有这两个独立标签的游戏，无法命中仅包含「科幻奇幻」「硬科幻」等关联标签的游戏（例如《海景房》），因为该游戏没有名为「科幻」的独立标签。

## 解决思路
整个提交遵循开闭原则，不影响原有的任何项目功能
- 将原有行为定义为「**精确模式**」
- 新增「**包含模式**」支持关联匹配

```
用户传入 tagName
        │
  [后宫结局, 科幻]
        │
        ▼  Meilisearch 分词 → 匹配关联标签
  { 后宫结局, [科幻, 硬科幻, 科幻奇幻] }
        │
        ▼  笛卡尔积 → 生成全部组合
  [后宫结局, 科幻]   [后宫结局, 硬科幻]   [后宫结局, 科幻奇幻]
        │
        ▼  逐一调用 multi-tag search → 去重合并
  [result galgame list]
```

在包含模式下，使用「后宫结局 + 科幻」即可搜到不含「科幻」标签但含「科幻奇幻」标签的《海景房》。

## 实现细节

### 前端

#### UI

遵循开闭原则：
- 将原有行为定义为「**精确模式**」
- 新增「**包含模式**」支持关联匹配

选择多标签搜索时，可通过下拉菜单切换两种模式：

<img width="209" height="109" alt="屏幕截图 2026-07-27 163926" src="https://github.com/user-attachments/assets/4bfbce62-0490-41a3-9574-62bcdde70c58" />
<img width="373" height="102" alt="屏幕截图 2026-07-27 163813" src="https://github.com/user-attachments/assets/9316ce45-66b0-4d59-a37d-2990d3c56417" />

#### 请求

仅新增包含模式的请求路径，指向独立端点，不修改原有精确匹配逻辑：

```ts
// kun-galgame-forum/apps/web/app/components/galgame/tag/Container.vue
if (matchMode.value === 'contains') {
  res = await kunFetch<{ galgames: GalgameCard[]; total: number }>(
    '/galgame-tag/multi-contains',
    {
      method: 'GET',
      query: {
        page: gamesPage.value,
        limit: gamesLimit,
        tagNames: selectedTags.value.map((t) => t.name).join(',')
      }
    }
  )
} else {
  // 原有多标签精确查询，未做修改
}
```

### 后端

#### Router

新增包含模式路由：

```go
// kun-galgame-forum/apps/api/internal/app/router.go
api.Get("/galgame-tag/multi-contains", a.GalgameEntityHandler.GetMultiTagGalgamesContains)
```

#### Handler

- 新增 `GetMultiTagGalgamesContains` 方法
- 新增 `atoiOr` 辅助方法

#### Service

- 新增 `GetByMultiTagContains` 方法 —— 核心业务逻辑
- 新增 `cartesianProduct` 辅助方法 —— 计算笛卡尔积

