### PR TITLE
fix(galgame): prevent score card header content from overflowing

### DIFF
--- a/apps/web/app/components/galgame/rating/radar/Card.vue
+++ b/apps/web/app/components/galgame/rating/radar/Card.vue
@@ -34,9 +34,13 @@ defineProps<{
         class-name="max-w-80"
       >
         <div class="flex items-center justify-between gap-3">
-          <div class="flex items-center gap-3">
-            <KunUserChip :disable-floating="true" :user="rating.user" />
-            <span class="text-default-500 text-sm">
+          <div class="flex min-w-0 items-center gap-3">
+            <KunUserChip
+              :disable-floating="true"
+              :user="rating.user"
+              className="min-w-0 flex-1"
+            />
+            <span class="text-default-500 shrink-0 text-sm">
               <KunTime :time="rating.created" />
             </span>
           </div>


### PR DESCRIPTION
### 背景 / 问题

Galgame 评分卡片（`kun-galgame-forum` 前端）在**用户昵称较长**时，卡片头部（用户名 + 时间戳）会把内容**横向挤出**固定宽度的卡片（`max-w-80`），导致卡片布局溢出、时间戳被挤掉或被遮挡。

<img width="1470" height="956" alt="截屏2026-07-31 18 03 34" src="https://github.com/user-attachments/assets/78e36d37-ad65-4e33-8c1a-5d87c2252dbd" />


<img width="1470" height="956" alt="截屏2026-08-04 14 59 31" src="https://github.com/user-attachments/assets/8bd7cb84-ab1f-4230-88f3-de6df3a6224e" />

涉及的组件：
`apps/web/app/components/galgame/rating/radar/Card.vue`

### 改动内容

对卡片头部 flex 布局做了三处调整，让内容可正确收缩而不是溢出：

1. **头部 flex 容器** 增加 `min-w-0`
   - 允许该 flex 项在空间不足时被压缩（默认 `min-width: auto` 会阻止收缩，导致溢出）

2. **`KunUserChip`** 增加 `min-w-0 flex-1`
   - 让用户信息占据剩余空间并可收缩，长昵称会被裁剪而不是把内容顶出卡片

3. **时间戳 `<span>`** 增加 `shrink-0`
   - 时间戳固定宽度、不允许压缩，保证始终完整显示

### 效果

- 长用户昵称不再导致卡片头部溢出
- 时间戳保持完整可见
- 卡片整体布局在窄尺寸下保持稳定
<img width="1470" height="956" alt="截屏2026-08-04 15 09 17" src="https://github.com/user-attachments/assets/747d3477-d9a1-4ce6-9fd1-6f3ddfe30dcc" />

---

### 测试说明

- 本地已验证：使用较长昵称的评分记录渲染，卡片头部不再横向溢出，时间戳完整显示
- 评分卡片在横向滚动条（`KunScrollShadow`）容器内布局正常

### 优化方向
 尝试尽力去展示用户名
 可以考虑随着用户名的长度增长增加卡片宽度，直到用户名实在过长（如20字以上）才考虑省略名称
 但是不知道是否有必要，以及改动有一点大，暂未采用

效果如下

<img width="1469" height="885" alt="截屏2026-08-03 21 28 35" src="https://github.com/user-attachments/assets/dba5b32c-2f29-4688-a0fe-2bd94c17937e" />

---
