### PR TITLE
feat: Galgame 工具集模糊名称搜索

### DIFF
--- a/apps/api/internal/toolset/dto/toolset_dto.go
+++ b/apps/api/internal/toolset/dto/toolset_dto.go
@@ -21,6 +21,9 @@ type ToolsetListRequest struct {
 	Version   string `query:"version"`
 	SortField string `query:"sort_field"`
 	SortOrder string `query:"sort_order"`
+	// Query is the keyword search across name + description + version (on the
+	// toolset row) and alias name (on galgame_toolset_alias). Empty = off.
+	Query string `query:"query" validate:"max=100"`
 	// UserID is set by the per-user handler (GET /user/:id/toolsets) from the
 	// path, NOT bound from the query — so the public /toolset list can't be
 	// author-filtered by an arbitrary caller.

--- a/apps/api/internal/toolset/repository/toolset_repo.go
+++ b/apps/api/internal/toolset/repository/toolset_repo.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"strings"
 	"time"
 
 	"kun-galgame-api/internal/toolset/model"
@@ -31,6 +32,9 @@ type ListFilters struct {
 	// UserID > 0 scopes the list to one author's toolsets (their profile 工具
 	// section). 0 = no author filter (the public list).
 	UserID int
+	// Query — keyword search across name + description + version (on the
+	// toolset row) and alias name (on galgame_toolset_alias). Empty = off.
+	Query string
 }
 
 // ListOptions holds sort + pagination parameters.
@@ -59,7 +63,19 @@ func (r *ToolsetRepository) buildListQuery(f ListFilters) *gorm.DB {
 	if f.UserID > 0 {
 		q = q.Where("user_id = ?", f.UserID)
 	}
+	if kw := strings.TrimSpace(f.Query); kw != "" {
+		q = q.Where("name ILIKE ?", "%"+escapeLike(kw)+"%")
+	}
 	return q
+}
+
+// escapeLike 转义 LIKE 模式中的通配符 % 和 _
+func escapeLike(s string) string {
+    return strings.NewReplacer(
+        "\\", "\\\\",
+        "%",  "\\%",
+        "_",  "\\_",
+    ).Replace(s)
 }
 
 // CountFiltered counts toolsets matching the filters.

--- a/apps/api/internal/toolset/service/toolset_service.go
+++ b/apps/api/internal/toolset/service/toolset_service.go
@@ -87,6 +87,7 @@ func (s *ToolsetService) GetList(ctx context.Context, req *dto.ToolsetListReques
 		Platform: req.Platform,
 		Version:  req.Version,
 		UserID:   req.UserID,
+		Query:    req.Query,
 	}
 	total := s.toolsetRepo.CountFiltered(filters)
 

--- a/apps/web/app/components/search/Container.vue
+++ b/apps/web/app/components/search/Container.vue
@@ -28,11 +28,25 @@ const isLoadComplete = computed(
 
 const searchQuery = async (searchType?: string): Promise<SearchPage> => {
   isLoading.value = true
+  const type = searchType || activeType.value
+  // toolset reuses the public /toolset list endpoint with its `query` keyword
+  // filter (BE has no /search?type=toolset). Same {items,total} envelope.
+  if (type === 'toolset') {
+    const result = await kunFetch<SearchPage>('/toolset', {
+      method: 'GET',
+      query: {
+        query: keywords.value,
+        ...pageData
+      }
+    })
+    isLoading.value = false
+    return result ?? { items: [], total: 0 }
+  }
   const result = await kunFetch<SearchPage>('/search', {
     method: 'GET',
     query: {
       keywords: keywords.value,
-      type: searchType || activeType.value,
+      type,
       ...pageData
     }
   })

--- a/apps/web/app/components/search/Result.vue
+++ b/apps/web/app/components/search/Result.vue
@@ -9,6 +9,9 @@ const isTopicResults = (results: unknown[]): results is SearchResultTopic[] =>
 const isGalgameResults = (
   results: unknown[]
 ): results is SearchResultGalgame[] => props.type === 'galgame'
+const isToolsetResults = (
+  results: unknown[]
+): results is SearchResultToolset[] => props.type === 'toolset'
 const isUserResults = (results: unknown[]): results is SearchResultUser[] =>
   props.type === 'user'
 const isReplyResults = (results: unknown[]): results is SearchResultReply[] =>
@@ -31,6 +34,8 @@ const isCommentResults = (
       v-if="isGalgameResults(results)"
       :galgames="results"
     />
+
+    <ToolsetCard v-if="isToolsetResults(results)" :items="results" />
 
     <div v-if="isUserResults(results)" class="space-y-3">
       <SearchUserCard

--- a/apps/web/app/components/search/items.ts
+++ b/apps/web/app/components/search/items.ts
@@ -13,7 +13,7 @@ export const navItems: NavItem[] = [
     value: 'galgame'
   },
   {
-    textValue: 'Galgame 工具',
+    textValue: 'Gal 工具资源',
     value: 'toolset'
   },
   {

--- a/apps/web/app/components/search/items.ts
+++ b/apps/web/app/components/search/items.ts
@@ -13,6 +13,10 @@ export const navItems: NavItem[] = [
     value: 'galgame'
   },
   {
+    textValue: 'Galgame 工具',
+    value: 'toolset'
+  },
+  {
     textValue: '用户',
     value: 'user'
   },

--- a/apps/web/app/components/toolset/card/Container.vue
+++ b/apps/web/app/components/toolset/card/Container.vue
@@ -10,7 +10,8 @@ const {
   platform,
   version,
   sortField,
-  sortOrder
+  sortOrder,
+  query
 } = useToolsetFilters()
 
 const { data, status } = await useKunFetch<{
@@ -26,7 +27,8 @@ const { data, status } = await useKunFetch<{
     platform,
     version,
     sort_field: sortField,
-    sort_order: sortOrder
+    sort_order: sortOrder,
+    query
   }
 })
 </script>

--- a/apps/web/app/components/toolset/card/Nav.vue
+++ b/apps/web/app/components/toolset/card/Nav.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { watchDebounced } from '@vueuse/core'
 import {
   kunGalgameToolsetTypeOptions,
   kunGalgameToolsetLanguageOptions,
@@ -12,7 +13,7 @@ import {
   KUN_GALGAME_TOOLSET_SORT_FIELD_MAP
 } from '~/constants/toolset'
 
-const { page, type, language, platform, version, sortField, sortOrder } =
+const { page, type, language, platform, version, sortField, sortOrder, query } =
   useToolsetFilters()
 
 watch(
@@ -28,9 +29,26 @@ watch(
     page.value = 1
   }
 )
+
+// Keyword search: reset to page 1 when the query changes so the user
+// always sees results from the top. Debounced so typing doesn't thrash
+// the URL/fetch on every keystroke.
+watchDebounced(
+  query,
+  () => {
+    page.value = 1
+  },
+  { debounce: 250 }
+)
 </script>
 
 <template>
+  <KunInput
+        v-model="query"
+        type="text"
+        placeholder="模糊名字查询"
+        class-name="col-span-2 lg:col-span-1"
+      />
   <div
     class="flex w-full shrink-0 flex-wrap items-center justify-between gap-3 rounded-lg border border-transparent sm:flex-nowrap"
   >

--- a/apps/web/app/composables/useToolsetFilters.ts
+++ b/apps/web/app/composables/useToolsetFilters.ts
@@ -38,6 +38,10 @@ export const useToolsetFilters = () => {
   )
   const sortOrder = useRouteQuery<KunOrder>('sortOrder', 'desc', opts)
 
+  // Keyword search across name + aliases + description + version. URL-backed
+  // like the other filters; empty string = no keyword filter (URL-omitted).
+  const query = useRouteQuery<string>('query', '', opts)
+
   const limit = 24
 
   return {
@@ -48,6 +52,7 @@ export const useToolsetFilters = () => {
     platform,
     version,
     sortField,
-    sortOrder
+    sortOrder,
+    query
   }
 }

--- a/apps/web/shared/types/search.ts
+++ b/apps/web/shared/types/search.ts
@@ -1,7 +1,9 @@
 import type { HomeTopic, HomeGalgame } from './home'
+import type { ToolsetCard } from './toolset'
 
 export type SearchResultTopic = HomeTopic
 export type SearchResultGalgame = HomeGalgame
+export type SearchResultToolset = ToolsetCard
 
 // BE `UserItem` (apps/api/internal/search/dto) currently leaves
 // `moemoepoint` and `created` zero — they're not joined from
@@ -35,10 +37,11 @@ export type SearchResultComment = {
   created: Date | string
 }
 
-export type SearchType = 'topic' | 'galgame' | 'user' | 'reply' | 'comment'
+export type SearchType = 'topic' | 'galgame' | 'toolset' | 'user' | 'reply' | 'comment'
 export type SearchResult =
   | SearchResultTopic
   | SearchResultGalgame
+  | SearchResultToolset
   | SearchResultUser
   | SearchResultReply
   | SearchResultComment


### PR DESCRIPTION
# feat: Galgame 工具集搜索

为 Toolset（Galgame 工具资源）列表新增关键词搜索能力，并在搜索页加入对应的「Gal 工具资源」标签页，让用户可以从站内搜索直接检索工具集。

<img width="904" height="262" alt="截屏2026-08-05 19 06 59" src="https://github.com/user-attachments/assets/ee2133b4-1769-417c-939a-ef850bf6eb81" />

## 新增效果

### Galgame 工具资源下载页面（/toolset ）在上方添加按名字模糊搜索栏
<img width="1470" height="956" alt="截屏2026-08-05 19 10 19" src="https://github.com/user-attachments/assets/dc2a67a5-05e3-4ec3-9153-0742d1617173" />
搜索效果:
<img width="1470" height="956" alt="截屏2026-08-05 19 11 10" src="https://github.com/user-attachments/assets/659df9fe-c89a-4ecd-ba7e-57e59efb436c" />

### 在默认搜索页面添加`Gal工具资源`选项
<img width="1470" height="956" alt="截屏2026-08-05 19 12 48" src="https://github.com/user-attachments/assets/3cce2f5b-64cb-4293-bf37-05e84cb8eb83" />
<img width="1470" height="956" alt="截屏2026-08-05 19 12 58" src="https://github.com/user-attachments/assets/0995bfdb-7443-4b58-8673-ec029405819e" />



## 后端
- 在 `ToolsetListRequest` 与 `ListFilters` 中新增 `Query` 字段
- `buildListQuery` 中按 `name ILIKE` 过滤，并对 LIKE 通配符做转义
- `Query` 参数在 service 层透传

## 前端
- `useToolsetFilters` 加入基于 URL 的 `query` 过滤项
- `Container.vue` 将 `query` 传入列表请求
- `Nav.vue` 新增搜索输入框，带防抖并重置分页
- 搜索页新增「Gal 工具资源」标签：复用现有 `GET /toolset` 端点的 `query` 过滤（无需新增 `/search?type=toolset`），结果通过既有 `ToolsetCard` 组件渲染
- `shared/types/search.ts` 新增 `SearchResultToolset` 类型，扩展 `SearchType` 与 `SearchResult` 联合类型
- `search/Container.vue` 在 `type === 'toolset'` 时分流到 `/toolset`
- `search/Result.vue` 新增 `isToolsetResults` 守卫与 `ToolsetCard` 渲染分支
- 将标签文案由 `Galgame 工具` 调整为 `Gal 工具资源`，保持命名一致

## 改动文件
- `apps/api/internal/toolset/dto/toolset_dto.go`
- `apps/api/internal/toolset/repository/toolset_repo.go`
- `apps/api/internal/toolset/service/toolset_service.go`
- `apps/web/app/components/toolset/card/Container.vue`
- `apps/web/app/components/toolset/card/Nav.vue`
- `apps/web/app/composables/useToolsetFilters.ts`
- `apps/web/app/components/search/Container.vue`
- `apps/web/app/components/search/Result.vue`
- `apps/web/app/components/search/items.ts`
- `apps/web/shared/types/search.ts`

---
