### PR TITLE
feat(galgame): maker logos + oauth doc mirror resync

### DIFF
--- a/apps/api/internal/galgame/client/banner.go
+++ b/apps/api/internal/galgame/client/banner.go
@@ -34,6 +34,21 @@ func bannerURLFromHash(cdnBase, hash string) string {
 		hash[:2] + "/" + hash[2:4] + "/" + hash + ".webp"
 }
 
+// ImageURLFromHash resolves any content hash the catalog hands over as a BARE
+// hash — a 会社 logo, say — to its absolute CDN URL, using the same layout and
+// the same configured base the banner walker uses.
+//
+// The walker itself cannot do this job: it keys off `image_hash` + `sort_order`
+// (a cover / screenshot row), and a logo is neither. Returns "" for an empty or
+// too-short hash, so a caller can pass the field through unchecked and get the
+// "no image" answer back.
+func (c *GalgameClient) ImageURLFromHash(hash string) string {
+	if c.imageCDNBase == "" {
+		return ""
+	}
+	return bannerURLFromHash(c.imageCDNBase, hash)
+}
+
 // rewriteBanners walks the galgame response JSON and, for every object
 // carrying U2 hash fields (`effective_banner_hash` / per-row
 // `image_hash` + `sort_order`), injects a CDN URL alongside (so the FE

--- a/apps/api/internal/galgame/client/catalog_label_logo_test.go
+++ b/apps/api/internal/galgame/client/catalog_label_logo_test.go
@@ -1,0 +1,126 @@
+package client
+
+// The 会社 logo lane (wave 170 P3). The catalog stores a label's brand mark as
+// a bare content hash on all three label faces — detail, browse list and entity
+// search — and this repo turns it into a CDN URL itself, because the banner
+// walker only fires on rows carrying `sort_order` and a logo has no such
+// sibling. Hermetic: an httptest server plays the catalog.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+const logoCDN = "https://image.example.test"
+
+func logoCatalog(t *testing.T) *GalgameClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/catalog/labels/107":
+			_, _ = w.Write([]byte(`{"code":0,"message":"成功","data":{"id":107,` +
+				`"display_name":"Purple SOFTWARE","logo_hash":"abcd1234ef"}}`))
+		// A maker with no logo, and a catalog that predates the field: both
+		// must read as "" rather than as an error or a broken URL.
+		case "/v1/catalog/labels/309":
+			_, _ = w.Write([]byte(`{"code":0,"message":"成功","data":{"id":309,"display_name":"无标社","logo_hash":""}}`))
+		case "/v1/catalog/labels/409":
+			_, _ = w.Write([]byte(`{"code":0,"message":"成功","data":{"id":409,"display_name":"旧契约社"}}`))
+		case "/v1/catalog/labels":
+			_, _ = w.Write([]byte(`{"code":0,"message":"成功","data":{"items":[` +
+				`{"id":107,"display_name":"Purple SOFTWARE","work_count":42,"logo_hash":"abcd1234ef"},` +
+				`{"id":309,"display_name":"无标社","work_count":3}],` +
+				`"next_cursor":null,"total":2}}`))
+		case "/v1/catalog/search":
+			_, _ = w.Write([]byte(`{"code":0,"message":"成功","data":{"items":[` +
+				`{"id":107,"entity_type":"label","name":"Purple SOFTWARE","logo_hash":"abcd1234ef"},` +
+				`{"id":309,"entity_type":"label","name":"无标社"}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":4,"message":"资源不存在"}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "test-key", logoCDN)
+}
+
+func TestImageURLFromHashFansOut(t *testing.T) {
+	c := logoCatalog(t)
+	const want = logoCDN + "/ab/cd/abcd1234ef.webp"
+	if got := c.ImageURLFromHash("abcd1234ef"); got != want {
+		t.Fatalf("logo URL = %q, want %q", got, want)
+	}
+	// "" in, "" out — the caller passes the field through unchecked, so the
+	// no-logo answer must never become a URL pointing at nothing.
+	if got := c.ImageURLFromHash(""); got != "" {
+		t.Fatalf("empty hash resolved to %q, want empty", got)
+	}
+	// A hash too short to fan out is the same non-answer, not a malformed path.
+	if got := c.ImageURLFromHash("ab"); got != "" {
+		t.Fatalf("short hash resolved to %q, want empty", got)
+	}
+	// No configured CDN base = no URLs at all (mirrors the banner walker).
+	if got := New("http://unused", "k", "").ImageURLFromHash("abcd1234ef"); got != "" {
+		t.Fatalf("unconfigured CDN resolved to %q, want empty", got)
+	}
+}
+
+func TestCatalogLabelCarriesLogoHash(t *testing.T) {
+	c := logoCatalog(t)
+	for _, tc := range []struct {
+		id   string
+		want string
+	}{
+		{"107", "abcd1234ef"},
+		{"309", ""},
+		// Absent field on an older catalog — additive contract, so this is a
+		// label without a logo, never a decode failure.
+		{"409", ""},
+	} {
+		rec, found, movedTo, appErr := c.CatalogLabel(context.Background(), tc.id)
+		if appErr != nil || !found || movedTo != 0 {
+			t.Fatalf("label %s: found=%v movedTo=%d err=%v", tc.id, found, movedTo, appErr)
+		}
+		if rec.LogoHash != tc.want {
+			t.Fatalf("label %s logo_hash = %q, want %q", tc.id, rec.LogoHash, tc.want)
+		}
+	}
+}
+
+func TestCatalogLabelListCarriesLogoHash(t *testing.T) {
+	rows, total, appErr := logoCatalog(t).CatalogTaxonomyPageAt(
+		context.Background(), "labels", url.Values{}, 1, 20)
+	if appErr != nil {
+		t.Fatalf("browse lane: %v", appErr)
+	}
+	if total != 2 || len(rows) != 2 {
+		t.Fatalf("browse lane returned %d rows (total %d), want 2/2", len(rows), total)
+	}
+	if rows[0].LogoHash != "abcd1234ef" {
+		t.Fatalf("row 0 logo_hash = %q, want abcd1234ef", rows[0].LogoHash)
+	}
+	if rows[1].LogoHash != "" {
+		t.Fatalf("row 1 logo_hash = %q, want empty", rows[1].LogoHash)
+	}
+}
+
+func TestCatalogLabelSearchCarriesLogoHash(t *testing.T) {
+	hits, appErr := logoCatalog(t).CatalogEntitySearch(
+		context.Background(), "labels", "purple", 20)
+	if appErr != nil {
+		t.Fatalf("entity search: %v", appErr)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("entity search returned %d hits, want 2", len(hits))
+	}
+	if hits[0].LogoHash != "abcd1234ef" {
+		t.Fatalf("hit 0 logo_hash = %q, want abcd1234ef", hits[0].LogoHash)
+	}
+	if hits[1].LogoHash != "" {
+		t.Fatalf("hit 1 logo_hash = %q, want empty", hits[1].LogoHash)
+	}
+}

--- a/apps/api/internal/galgame/client/catalog_taxonomy.go
+++ b/apps/api/internal/galgame/client/catalog_taxonomy.go
@@ -49,6 +49,14 @@ type CatalogTaxonomyItem struct {
 	// would otherwise report every series as clean and put r18 covers in front
 	// of SFW readers. nil = unanswered, and the caller probes instead.
 	HasNSFW *bool `json:"has_nsfw"`
+	// LogoHash is the label's 会社 logo, content-addressed in image_service —
+	// label lane only, "" when the maker has none (and on a catalog that
+	// predates the field, which is why absent must read as "no logo" and never
+	// as an error). Resolve it with GalgameClient.ImageURLFromHash; the banner
+	// walker does not touch it, since it carries no `sort_order` sibling.
+	//
+	// Always SFW (the catalog stores logos with sexual=0), so no gate here.
+	LogoHash string `json:"logo_hash"`
 }
 
 // TagTierHidden is the canonical vocabulary's "do not display" tier. Upstream
@@ -90,6 +98,8 @@ type CatalogLabelDetail struct {
 	WorkCount   int                `json:"work_count"`
 	Intros      []CatalogIntro     `json:"intros"`
 	Links       []CatalogLabelLink `json:"links"`
+	// LogoHash — see CatalogTaxonomyItem.LogoHash.
+	LogoHash string `json:"logo_hash"`
 }
 
 // CatalogLabelLink is one of a label's web presences. Source is the catalog's
@@ -291,6 +301,10 @@ type CatalogEntityHit struct {
 	// no `sexual` flag, which is why the SFW gate needs CatalogSexualTagIDs.
 	Tier string `json:"tier"`
 	Kind string `json:"kind"`
+	// LogoHash rides LABEL hits only — the one piece of non-identity data the
+	// hit shape carries, because a maker picker that shows the brand mark is
+	// the whole point and a second round trip per hit is not. "" elsewhere.
+	LogoHash string `json:"logo_hash"`
 }
 
 // CatalogEntitySearch runs the shared entity search. searchType is the face's

--- a/apps/api/internal/galgame/dto/entity_dto.go
+++ b/apps/api/internal/galgame/dto/entity_dto.go
@@ -78,6 +78,11 @@ type GalgameSample struct {
 type TaxonomySearchItem struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
+	// Logo is the LABEL hit's ready-made 会社 logo URL — the one exception to
+	// "identity and nothing else", because the brand mark IS identity for a
+	// maker and the catalog ships its hash inline on the hit. omitempty: a tag
+	// hit has no logo and must not claim an empty one.
+	Logo string `json:"logo,omitempty"`
 }
 
 // ──────────────────────────────────────────
@@ -85,10 +90,16 @@ type TaxonomySearchItem struct {
 // ──────────────────────────────────────────
 
 type OfficialListItem struct {
-	ID           int      `json:"id"`
-	Name         string   `json:"name"`
-	Link         string   `json:"link"`
-	Category     string   `json:"category"`
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Link     string `json:"link"`
+	Category string `json:"category"`
+	// Logo is the 会社 logo as a READY-MADE absolute CDN URL (original size —
+	// the FE derives the `_mini` variant with withImageVariant, the same way it
+	// does for galgame banners), "" when the maker has no logo. A URL rather
+	// than a hash so no consumer has to know the CDN layout, matching how every
+	// other catalog-derived image reaches this face.
+	Logo         string   `json:"logo"`
 	Lang         string   `json:"lang"`
 	Alias        []string `json:"alias"`
 	GalgameCount int      `json:"galgame_count"`
@@ -117,14 +128,17 @@ type OfficialDetail struct {
 	// carries, each with the source key that names it — a 会社 whose only
 	// presence is an X account has an empty Link and one entry here, which is
 	// the honest reading of "no official site, but you can still find them".
-	Links        []OfficialLink `json:"links"`
-	Link         string         `json:"link"`
-	Category     string         `json:"category"`
-	Lang         string         `json:"lang"`
-	Description  string         `json:"description"`
-	Alias        []string       `json:"alias"`
-	Galgame      []GalgameCard  `json:"galgame"`
-	GalgameCount int64          `json:"galgame_count"`
+	Links []OfficialLink `json:"links"`
+	Link  string         `json:"link"`
+	// Logo — see OfficialListItem.Logo. "" when the maker has no logo, which is
+	// the page's cue to render the name alone rather than a broken frame.
+	Logo         string        `json:"logo"`
+	Category     string        `json:"category"`
+	Lang         string        `json:"lang"`
+	Description  string        `json:"description"`
+	Alias        []string      `json:"alias"`
+	Galgame      []GalgameCard `json:"galgame"`
+	GalgameCount int64         `json:"galgame_count"`
 	// MovedTo is the ONLY field set when this label id was merged away
 	// upstream: the identity now lives on that catalog label id and the page
 	// must 301 to it in a single hop. Everything else stays zero on purpose —

--- a/apps/api/internal/galgame/service/official_service.go
+++ b/apps/api/internal/galgame/service/official_service.go
@@ -63,7 +63,10 @@ func (s *OfficialService) GetList(
 			// The browse row is identity + count; the maker's website lives on
 			// the record (links[]), which the detail page fetches. The list
 			// cards never rendered a website anyway.
-			Category:     o.Kind,
+			Category: o.Kind,
+			// The one image the browse row does carry. Resolved here rather
+			// than shipped as a hash so the card can render it straight.
+			Logo:         s.galgameClient.ImageURLFromHash(o.LogoHash),
 			Alias:        emptyStrSliceIfNil(o.Aliases),
 			GalgameCount: o.WorkCount,
 		})
@@ -73,9 +76,10 @@ func (s *OfficialService) GetList(
 
 // Search — GET /galgame-official/search
 //
-// Identity only: the upstream search face returns id + name and nothing else,
-// so this answers in the search shape rather than dressing a hit up as a browse
-// row whose count, category and language would all be zero values.
+// Identity only: the upstream search face returns id + name (+ the label's logo
+// hash, which for a maker IS identity) and nothing else, so this answers in the
+// search shape rather than dressing a hit up as a browse row whose count,
+// category and language would all be zero values.
 //
 // The frontend does `searchResult.value = res` expecting a bare array, so the
 // envelope is unwrapped here and the gateway response shape stays put.
@@ -90,7 +94,11 @@ func (s *OfficialService) Search(
 	}
 	items := make([]dto.TaxonomySearchItem, 0, len(hits))
 	for _, o := range hits {
-		items = append(items, dto.TaxonomySearchItem{ID: int(o.ID), Name: o.Name})
+		items = append(items, dto.TaxonomySearchItem{
+			ID:   int(o.ID),
+			Name: o.Name,
+			Logo: s.galgameClient.ImageURLFromHash(o.LogoHash),
+		})
 	}
 	return items, nil
 }
@@ -141,6 +149,7 @@ func (s *OfficialService) GetDetail(
 		// alternate spellings are in alias[].
 		Links:       officialLinks(o.Links),
 		Link:        client.PrimaryLabelLink(o),
+		Logo:        s.galgameClient.ImageURLFromHash(o.LogoHash),
 		Category:    o.Kind,
 		Lang:        o.Lang,
 		Description: preferredIntro(o.Intros),

--- a/apps/web/app/components/galgame/official/Card.vue
+++ b/apps/web/app/components/galgame/official/Card.vue
@@ -22,6 +22,15 @@ const detail = computed(() =>
 // list has been showing "publisher" and "group" chips.
 const categoryText = (category: string) =>
   KUN_GALGAME_OFFICIAL_CATEGORY_MAP[category] || category
+
+// The brand mark, at the `_mini` (360px) variant — a 64px thumbnail has no use
+// for the original. Both shapes carry it: a browse row and a search hit alike,
+// which is what lets the search results show the logo without a second lookup.
+// '' (or absent, on a maker with no logo) means render nothing and let the name
+// take the full width — an empty frame reads as a broken image.
+const logoSrc = computed(() =>
+  props.official.logo ? withImageVariant(props.official.logo, 'mini') : ''
+)
 </script>
 
 <template>
@@ -30,12 +39,24 @@ const categoryText = (category: string) =>
     :is-hoverable="true"
     :href="`/galgame/official/${official.id}`"
   >
-    <h3 class="text-default-900 font-semibold">
-      {{ official.name }}
-      <KunChip v-if="detail" size="xs">
-        {{ `+ ${detail.galgame_count}` }}
-      </KunChip>
-    </h3>
+    <div class="flex items-center gap-2">
+      <!-- object-contain, never cover: a brand mark cropped to a square is a
+           different logo. The frame is omitted entirely when there is none. -->
+      <KunImage
+        v-if="logoSrc"
+        :src="logoSrc"
+        :alt="`${official.name} logo`"
+        loading="lazy"
+        object-fit="contain"
+        class-name="size-10 shrink-0 rounded-md"
+      />
+      <h3 class="text-default-900 min-w-0 font-semibold">
+        {{ official.name }}
+        <KunChip v-if="detail" size="xs">
+          {{ `+ ${detail.galgame_count}` }}
+        </KunChip>
+      </h3>
+    </div>
     <div v-if="detail" class="flex items-center gap-x-2">
       <KunChip size="xs" class-name="rounded-md" color="primary">
         {{ categoryText(detail.category) }}

--- a/apps/web/app/pages/galgame/official/[id].vue
+++ b/apps/web/app/pages/galgame/official/[id].vue
@@ -135,6 +135,21 @@ if (!moved) {
       :name="`${data.name} 制作的 Galgame`"
       :description="data.description"
     >
+      <!-- The 会社's own brand mark, at full size (the header frame is large
+           enough that the 360px `_mini` variant would show its resampling).
+           Logos are always SFW upstream, so no content gate sits in front of
+           it. A maker with none renders no frame at all — the header simply
+           looks the way it always has. -->
+      <template v-if="data.logo" #headerEndContent>
+        <KunImage
+          :src="data.logo"
+          :alt="`${data.name} logo`"
+          loading="eager"
+          object-fit="contain"
+          class-name="size-16 shrink-0 rounded-md sm:size-20"
+        />
+      </template>
+
       <template #endContent>
         <div class="space-y-3">
           <p class="text-default-500">

--- a/apps/web/shared/types/galgame-official.ts
+++ b/apps/web/shared/types/galgame-official.ts
@@ -25,6 +25,11 @@ export interface GalgameOfficialItem {
   lang: string
   alias: string[]
   galgame_count: number
+  /** The 会社 logo as a ready-made absolute CDN URL (original size — use
+   * `withImageVariant(logo, 'mini')` for the thumbnail). `''` when the maker
+   * has no logo; optional because the galgame-detail labels[] lane shares this
+   * shape and sends none. Always SFW, so no content gate applies. */
+  logo?: string
 }
 
 // One of a 会社's web presences. `source` is the catalog's own key
@@ -47,6 +52,9 @@ export interface GalgameOfficialDetail {
   // is every presence the catalog carries, each labelled by its source.
   links: GalgameOfficialLink[]
   link: string
+  /** See GalgameOfficialItem.logo. `''` when the maker has no logo — the page
+   * then renders the name alone rather than an empty frame. */
+  logo: string
   category: KunGalgameOfficialCategory
   lang: string
   description: string

--- a/apps/web/shared/types/galgame-tag.ts
+++ b/apps/web/shared/types/galgame-tag.ts
@@ -22,6 +22,10 @@ export interface GalgameTagItem {
 export interface GalgameTaxonomySearchItem {
   id: number
   name: string
+  /** The one exception to identity-only, and only on 会社 (label) hits: a
+   * ready-made logo URL, because the brand mark IS a maker's identity. Absent
+   * on tag hits and on makers with no logo. */
+  logo?: string
 }
 
 export interface GalgameTagDetail {

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -11,4 +11,4 @@
 - **提示 / 警告用文字标签**:「注意:」「重要:」「已实现:」等,不用 emoji 前缀。
 - **可保留**(等宽渲染一致、属结构而非装饰):ASCII 制表符 `┌─┘├`、几何箭头 `▲ ► ▼`、圈号步骤 `① ② ③`、纯文本箭头 `→ ← ↓`、键盘快捷键写文字(如 `Cmd+K`)。
 
-> 注意:`docs/oauth`、`docs/image_service`、`docs/galgame_wiki` 是 infra 契约的**生成镜像**,勿手改;由 `kungal-docs` 的 `docs:sync` 下发。
+> 注意:`docs/oauth`、`docs/image_service`、`docs/artifact` 是 infra 契约的**生成镜像**,勿手改;由 `kungal-docs` 的 `docs:sync` 下发。

--- a/docs/oauth/05-registration.md
+++ b/docs/oauth/05-registration.md
@@ -193,7 +193,8 @@
     "id": "4ed9bc99ec0a789a4796b83e22bd84c5",
     "name": "鲲 Galgame 论坛",
     "auto_consent": true,
-    "site_domain": "www.kungal.com"
+    "site_domain": "www.kungal.com",
+    "logo_url": "https://image.moyu.moe/image/abc123"
   }
 }
 ```
@@ -204,6 +205,7 @@
 | name | 展示名 |
 | auto_consent | 第一方 client 标志；为 true 时前端**跳过同意页**，直接 POST `/oauth/authorize/consent` |
 | site_domain | 关联 site 的 domain（可空），用于展示"将跳转回 X" |
+| logo_url | 应用图标（可空，与 `/oauth/ecosystem` 同一张图），同意页用它替代首字母占位 |
 
 > **不返回**：`secret`、`redirect_uris`、`scopes` 等敏感 / 实现细节。这个端点只为前端判定 UI 行为服务。
 


### PR DESCRIPTION
Wave 170 P3: the 会社/official surfaces now show the brand logo the catalog carries (list cards via the _mini variant, detail header at original size; empty hash renders exactly as before). Also resyncs the oauth registration doc mirror from the infra source and the vendored-mirror list note. Additive against the catalog faces shipped in infra main (logo_hash, "" = none).