### PR TITLE
fix(toolset): hide pagination card when search results are empty and fix style error

### DIFF
--- a/apps/web/app/components/toolset/card/Container.vue
+++ b/apps/web/app/components/toolset/card/Container.vue
@@ -47,10 +47,12 @@ const { data, status } = await useKunFetch<{
     </div>
 
     <KunLoading :loading="status === 'pending'">
-      <ToolsetCard v-if="data.items" :items="data.items" />
+      <ToolsetCard v-if="data.items.length" :items="data.items" />
+      <KunNull v-else description="没有找到符合条件的工具资源" />
     </KunLoading>
 
     <KunCard
+      v-if="data.items.length"
       :is-hoverable="false"
       :is-transparent="false"
       content-class="gap-3"


### PR DESCRIPTION
## Summary

搜索工具资源结果为空时，底部分页卡片仍然显示，且空状态的 `KunNull` 无法正常展示。
并且伴随样式错误

<img width="1470" height="956" alt="截屏2026-08-06 11 20 44" src="https://github.com/user-attachments/assets/1488f69e-1375-405e-9976-98aec2ae44f8" />

## Root Cause

`Container.vue` 中使用 `v-if="data.items"` 控制分页卡片和 `ToolsetCard` 的渲染。后端在结果为空时返回的 `data.items` 为空数组 `[]`，而空数组是 truthy 值，导致条件始终为 `true`。

## Changes
-增加结果为空时的`KunNull`组件
- 将 `ToolsetCard` 的 `v-if="data.items"` 改为 `v-if="data.items.length"`，使结果为空时正确回退到 `KunNull` 空状态
- 添加Card`（分页）的  `v-if="data.items.length"`，结果为空时隐藏分页

## Impact

- 结果为空时不再渲染空的工具卡片和分页组件
- 正确展示「没有找到符合条件的工具资源」空状态
<img width="1470" height="956" alt="截屏2026-08-06 11 50 27" src="https://github.com/user-attachments/assets/2c11fd3f-f9c2-45c9-bc8f-2929934f1932" />
