### PR TITLE
fix(galgame): hide pagination card when search results are empty and fix style error

### DIFF
--- a/apps/web/app/components/galgame/card/Container.vue
+++ b/apps/web/app/components/galgame/card/Container.vue
@@ -87,10 +87,12 @@ watch([() => route.fullPath, showKUNGalgameNoResource], () => {
       </div>
 
       <KunLoading :loading="status === 'pending'">
-        <GalgameCard v-if="data.galgames" :galgames="data.galgames" />
+        <GalgameCard v-if="data.galgames.length" :galgames="data.galgames" />
+        <KunNull v-else description="没有找到符合条件的 Galgame" />
       </KunLoading>
 
       <KunCard
+        v-if="data.galgames.length"
         :is-hoverable="false"
         :is-transparent="false"
         content-class="gap-3"


### PR DESCRIPTION
## Summary

Galgame 卡片列表在搜索/筛选结果为空时，仍会渲染空的 `GalgameCard` 与分页卡片，因为没有结果时 `data.galgames` 是空数组（truthy），原 `v-if="data.galgames"` 判断失效。
并且会出现样式问题

本 PR 与 `4fa184f1`(toolset) 同类问题，将判断改为 `data.galgames.length`，并在无结果时显示 `KunNull` 占位、隐藏分页卡片。
<img width="1470" height="956" alt="截屏2026-08-06 11 52 13" src="https://github.com/user-attachments/assets/e94c43ef-eac9-49a4-93b7-ad7be6ca5dee" />


## Changes

- `apps/web/app/components/galgame/card/Container.vue`
  - `GalgameCard` 的 `v-if` 由 `data.galgames` 改为 `data.galgames.length`
  - 无结果时渲染 `<KunNull description="没有找到符合条件的 Galgame" />`
  - 分页 `KunCard` 增加 `v-if="data.galgames.length"`，空结果时隐藏

## Why

空数组在 JS 中为 truthy，`v-if="data.galgames"` 无法正确判断“无结果”，导致空列表下仍展示分页器与空白卡片。

## Test

- 搜索/筛选无匹配结果时，显示「没有找到符合条件的 Galgame」且分页卡片消失
- 有结果时分页与卡片行为不变
<img width="1470" height="956" alt="截屏2026-08-06 14 47 06" src="https://github.com/user-attachments/assets/2d821b67-4594-4f70-8df9-b2798f3e4d48" />
<img width="1470" height="956" alt="截屏2026-08-06 14 57 10" src="https://github.com/user-attachments/assets/25536450-fe45-4b3c-b8c4-4fc2a64e70cc" />

