### PR TITLE
修复首页轮播拖拽问题并调整本地开发环境配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Start the local shared platform first:
 
 ```bash
 cd /path/to/kun-galgame-infra
-docker compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml --profile full up -d
 # Optional: refresh the local databases with real-shaped, desensitized data.
 ./scripts/refresh-dev-db.sh
 ```

--- a/apps/api/.air.toml
+++ b/apps/api/.air.toml
@@ -8,10 +8,9 @@ testdata_dir = "testdata"
 tmp_dir = "tmp"
 
 [build]
-# Build command
+# Default build command and entrypoint for Linux and macOS
 cmd = "go build -o ./tmp/server ./cmd/server"
-# Binary entrypoint to run
-entrypoint = "./tmp/server"
+entrypoint = ["./tmp/server"]
 # Watch these extensions
 include_ext = ["go", "tpl", "tmpl", "html", "env"]
 # Exclude directories
@@ -39,6 +38,11 @@ kill_delay = "0s"
 # Rerun on error
 rerun = false
 rerun_delay = 500
+
+# Windows requires an .exe suffix. Air applies this block only on Windows.
+[build.windows]
+cmd = "go build -o ./tmp/server.exe ./cmd/server"
+entrypoint = ["./tmp/server.exe"]
 
 [color]
 app = ""

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,7 +2,8 @@
 # kungal API (apps/api) — LOCAL DEV env. Copy to apps/api/.env (godotenv loads it).
 #
 # Turnkey against the kun-galgame-infra dev stack. Onboarding is three steps:
-#   1. cd ../kun-galgame-infra && docker compose -f docker-compose.dev.yml up -d
+#   1. cd ../kun-galgame-infra && pnpm dev:full
+#      # Equivalent: docker compose -f docker-compose.dev.yml --profile full up -d
 #   2. (optional) ./scripts/refresh-dev-db.sh        # real-shaped, desensitised data
 #   3. cp apps/api/.env.example apps/api/.env         # this file, then `pnpm dev`
 #
@@ -62,9 +63,8 @@ MAIL_FROM=鲲 Galgame (dev) <dev@dev.local>
 MEILISEARCH_URL=http://127.0.0.1:7700
 MEILISEARCH_KEY=kun-dev-meili-master-key-local-only
 
-# NextMoe catalog galgame surface (dev catalog instance :19281; HOST base, no
-# /api suffix). Reads → {base}/internal + X-API-Key; writes/admin/feeds →
-# {base}/api.
+# NextMoe catalog galgame read surface (dev catalog instance :9281; host base,
+# no path suffix). The client calls {base}/v1/catalog/* with X-API-Key.
 #
 # The KEY is REQUIRED — the keyless-fallback valve was removed in wave 05, so an
 # empty value now fail-fasts at config load rather than degrading to the legacy
@@ -72,10 +72,10 @@ MEILISEARCH_KEY=kun-dev-meili-master-key-local-only
 # app's OAUTH_CLIENT_ID (internal tier); only the sha256 hash is stored upstream,
 # so a key that predates a dev-DB re-mint can never match and every galgame read
 # answers 401 "未授权，请先登录" from the devapi middleware — not a session
-# problem. Mint a fresh one in the developer portal, or seed a local row keyed by
-# the deterministic dev plaintext nm_test_dev<OAUTH_CLIENT_ID>.
-KUN_NEXTMOE_API_BASE=http://127.0.0.1:19281
-KUN_NEXTMOE_API_KEY=
+# problem. This example contains the deterministic local test plaintext matching
+# the forum application's developer_api_keys row in the dev database.
+KUN_NEXTMOE_API_BASE=http://127.0.0.1:9281
+KUN_NEXTMOE_API_KEY=nm_test_dev4ed9bc99ec0a789a4796b83e22bd84c5
 
 # Catalog service (dev stack catalog :9281) — the editing engine's S2S
 # actor-assertion face (staff/owner writes + the whole review chain); auth

--- a/apps/api/internal/galgame/client/client.go
+++ b/apps/api/internal/galgame/client/client.go
@@ -132,19 +132,12 @@ type GalgameClient struct {
 
 // New builds a galgame client for the NextMoe catalog service.
 //
-// baseURL is the NextMoe host base (e.g. http://catalog:9281, no /api or
-// /internal suffix); the client derives {base}/internal (the internal-tier
-// read face, the two cron feeds, and the user write set, all gated by
-// X-API-Key) and {base}/api (the legacy staff face: taxonomy writes +
-// /admin/* reads).
+// baseURL is the NextMoe host base (e.g. http://catalog:9281, with no path
+// suffix); the client derives {base}/v1 and calls its /catalog projection.
 //
-// apiKey is the internal-tier devapi key sent as X-API-Key on every
-// internal-face call — reads, both feeds, and the user write set. It is
-// REQUIRED: the internal face rejects keyless calls with 401 and there is no
-// keyless-fallback valve any more (config load fail-fasts when a base is
-// configured without a key). The user's Bearer JWT rides Authorization in
-// parallel with X-API-Key on personalized reads / submissions / writes
-// (dual-credential transport).
+// apiKey is the developer API key sent as X-API-Key on every call. It is
+// REQUIRED: the public projection rejects keyless calls with 401 and config
+// loading fails fast when the key is absent.
 //
 // imageCDNBase must match the service's KUN_IMAGE_PUBLIC_BASE_URL so
 // hash-backed banners resolve to the same CDN URLs the service would build.

--- a/apps/api/pkg/config/config.go
+++ b/apps/api/pkg/config/config.go
@@ -122,12 +122,10 @@ type ImageClientConfig struct {
 }
 
 // NextMoeAPIConfig holds how kungal reaches the NextMoe catalog service's
-// galgame surface. BaseURL is the HOST base (no /api or /internal suffix); the
-// galgame client derives {base}/internal (internal-tier read face, X-API-Key)
-// and {base}/api (legacy face for writes / admin / feeds). APIKey is the
-// internal-tier devapi key sent as X-API-Key on read calls and both feeds. It
-// is REQUIRED — Load() fail-fasts when a base is configured without a key;
-// there is no keyless-fallback valve any more (wave 05).
+// galgame surface. BaseURL is the host base with no path suffix; the galgame
+// client derives {base}/v1 and calls the /catalog public projection. APIKey is
+// the developer API key sent as X-API-Key on every call. It is REQUIRED —
+// Load() fail-fasts when a base is configured without a key.
 type NextMoeAPIConfig struct {
 	BaseURL string
 	APIKey  string
@@ -250,11 +248,11 @@ func Load() (*Config, error) {
 	// (wave 05). A base configured without a key is a misconfiguration: fail
 	// fast at startup, loudly naming the env var, rather than silently 401 on
 	// every read at runtime. No silent degradation.
-	nextMoeBase := envOrDefault("KUN_NEXTMOE_API_BASE", "http://127.0.0.1:19281")
+	nextMoeBase := envOrDefault("KUN_NEXTMOE_API_BASE", "http://127.0.0.1:9281")
 	nextMoeKey := envOrDefault("KUN_NEXTMOE_API_KEY", "")
 	if nextMoeBase != "" && nextMoeKey == "" {
 		return nil, fmt.Errorf(
-			"KUN_NEXTMOE_API_KEY 未设置: catalog galgame 读面 (internal 面) 硬依赖 internal-tier API key; 已配置 KUN_NEXTMOE_API_BASE=%q 但 KUN_NEXTMOE_API_KEY 为空 (keyless 回退阀已在 wave 05 移除, 不做静默降级)",
+			"KUN_NEXTMOE_API_KEY 未设置: catalog /v1 读面硬依赖 developer API key; 已配置 KUN_NEXTMOE_API_BASE=%q 但 KUN_NEXTMOE_API_KEY 为空, 不做静默降级",
 			nextMoeBase,
 		)
 	}
@@ -311,11 +309,11 @@ func Load() (*Config, error) {
 			),
 		},
 		NextMoeAPI: NextMoeAPIConfig{
-			// Host base, no /api suffix; the galgame client derives
-			// {base}/internal (read face + feeds) + {base}/api (legacy face).
-			// Dev default = local catalog dev instance on :19281.
+			// Host base with no path suffix; the galgame client derives
+			// {base}/v1 and calls the /catalog public projection.
+			// Dev default = the local catalog service on :9281.
 			BaseURL: nextMoeBase,
-			// Internal-tier devapi key (X-API-Key) for the read face + feeds.
+			// Developer API key (X-API-Key) for the catalog read face.
 			// REQUIRED — validated above (fail-fast; no keyless fallback).
 			APIKey: nextMoeKey,
 			// Must match the service's KUN_IMAGE_PUBLIC_BASE_URL exactly —

--- a/apps/web/app/components/home/Carousel.vue
+++ b/apps/web/app/components/home/Carousel.vue
@@ -65,7 +65,6 @@ const startDrag = (e: MouseEvent | TouchEvent) => {
 
 const onDrag = (e: MouseEvent | TouchEvent) => {
   if (!isDragging.value) return
-  e.preventDefault()
   const currentX =
     e instanceof MouseEvent
       ? e.clientX
@@ -80,7 +79,11 @@ const onDrag = (e: MouseEvent | TouchEvent) => {
 const endDrag = () => {
   if (!isDragging.value) return
   if (Math.abs(dragOffset.value) > DRAG_THRESHOLD) {
-    dragOffset.value > 0 ? prevSlide() : nextSlide()
+    if (dragOffset.value > 0) {
+      prevSlide()
+    } else {
+      nextSlide()
+    }
   }
   isDragging.value = false
   dragOffset.value = 0
@@ -88,12 +91,20 @@ const endDrag = () => {
 }
 
 const manualSlide = (direction: 'next' | 'prev') => {
-  direction === 'next' ? nextSlide() : prevSlide()
+  if (direction === 'next') {
+    nextSlide()
+  } else {
+    prevSlide()
+  }
   startAutoplay()
 }
 
 watch(isOutside, (outside) => {
-  outside ? startAutoplay() : stopAutoplay()
+  if (outside) {
+    startAutoplay()
+  } else {
+    stopAutoplay()
+  }
 })
 
 onMounted(() => startAutoplay())
@@ -101,18 +112,21 @@ onBeforeUnmount(() => stopAutoplay())
 </script>
 
 <template>
-  <KunCard
-    :is-hoverable="false"
+<KunCard :is-hoverable="false" class-name="overflow-hidden p-0">
+  <div
     ref="carouselRef"
+    class="group relative cursor-grab overflow-hidden touch-pan-y"
     @mousedown="startDrag"
     @mousemove="onDrag"
     @mouseup="endDrag"
     @mouseleave="endDrag"
+    @dragstart.prevent
     @touchstart.passive="startDrag"
     @touchmove.passive="onDrag"
     @touchend="endDrag"
-    class-name="group relative cursor-grab overflow-hidden p-0"
+    @touchcancel="endDrag"
   >
+  
     <template v-if="pinnedPosts.length">
       <div
         class="flex"
@@ -184,5 +198,6 @@ onBeforeUnmount(() => stopAutoplay())
     </template>
 
     <KunNull v-else description="暂时没有置顶文档" />
-  </KunCard>
+  </div>
+</KunCard>
 </template>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -86,13 +86,11 @@ x-kungal-api-env: &kungal-api-env
   # search — key MUST == infra MEILI_MASTER_KEY
   MEILISEARCH_URL: http://meilisearch:7700
   MEILISEARCH_KEY: ${MEILI_MASTER_KEY:?set MEILI_MASTER_KEY in Dokploy (= infra 的同名值)}
-  # NextMoe catalog galgame surface (host base, no /api suffix): the client
-  # derives {base}/internal (internal-tier read face, X-API-Key) + {base}/api
-  # (legacy face for writes / admin / feeds).
+  # NextMoe catalog galgame read surface (host base with no path suffix): the
+  # client calls {base}/v1/catalog/* with X-API-Key.
   KUN_NEXTMOE_API_BASE: http://catalog:9281
-  # internal-tier devapi key for the read face (X-API-Key). REQUIRED whenever a
-  # base is set: an empty key fail-fasts at config load (the legacy /api rollback
-  # valve was retired in open-API phase 2 wave 05). Set in Dokploy; plaintext in
+  # Developer API key for the read face (X-API-Key). REQUIRED whenever a base
+  # is set: an empty key fails fast at config load. Set in Dokploy; plaintext in
   # kungal-neo /root/phase2-internal-keys.env (kungal-forum-internal-s2s).
   KUN_NEXTMOE_API_KEY: ${KUN_NEXTMOE_API_KEY:-}
   # catalog read proxy (step 36): credits / entity reverse-lookups. Reuses the

--- a/docker/api.env.example
+++ b/docker/api.env.example
@@ -51,11 +51,11 @@ MAIL_FROM=
 MEILISEARCH_URL=http://meilisearch:7700
 MEILISEARCH_KEY=
 
-# NextMoe catalog galgame surface (prod catalog :9281; HOST base, no /api
-# suffix). Reads → {base}/internal + X-API-Key; writes/admin/feeds → {base}/api.
+# NextMoe catalog galgame read surface (prod catalog :9281; host base with no
+# path suffix). The client calls {base}/v1/catalog/* with X-API-Key.
 KUN_NEXTMOE_API_BASE=http://catalog:9281
-# internal-tier devapi key (X-API-Key) for the read face. Empty → reads fall
-# back to the legacy /api face (rollback valve). Do NOT commit a real key.
+# Developer API key (X-API-Key) for the read face. It is required; an empty
+# value makes the API fail fast during startup. Do not commit a real key.
 KUN_NEXTMOE_API_KEY=
 
 # image_service — public CDN prefix. MUST equal infra's KUN_IMAGE_PUBLIC_BASE_URL

--- a/docs/readme/chs.md
+++ b/docs/readme/chs.md
@@ -107,7 +107,7 @@
 
 ```bash
 cd /path/to/kun-galgame-infra
-docker compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml --profile full up -d
 # 可选：使用形状接近真实数据、经过脱敏的内容刷新本地数据库。
 ./scripts/refresh-dev-db.sh
 ```

--- a/docs/readme/cht.md
+++ b/docs/readme/cht.md
@@ -107,7 +107,7 @@
 
 ```bash
 cd /path/to/kun-galgame-infra
-docker compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml --profile full up -d
 # 選用：以形狀接近真實資料、經過去識別化的內容重新整理本地資料庫。
 ./scripts/refresh-dev-db.sh
 ```

--- a/docs/readme/jp.md
+++ b/docs/readme/jp.md
@@ -107,7 +107,7 @@
 
 ```bash
 cd /path/to/kun-galgame-infra
-docker compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml --profile full up -d
 # 任意：本番に近い形で匿名化されたデータを使い、ローカル DB を更新します。
 ./scripts/refresh-dev-db.sh
 ```


### PR DESCRIPTION
## 改动内容

### 首页轮播拖拽

- 将轮播尺寸引用从 `KunCard` 组件实例移动到原生容器，确保能够正确读取 `offsetWidth`。
- 使用 passive 触摸监听配合 `touch-pan-y`，补充 `touchcancel` 清理。
- 阻止链接和图片的原生拖拽。
- 清理轮播内三处仅用于副作用的三元表达式。

### 本地开发环境与文档

- 开发环境统一使用 infra 完整 profile，并同步相关 README。
- 将 NextMoe Catalog 本地地址切换到 `127.0.0.1:9281`，使用 `/v1/catalog/*` 公共读取面。
- 配置与最新 dev seed 匹配的确定性开发 API Key。
- 更新 API 配置、Docker 示例及客户端注释，使其与当前 Catalog 契约一致。
- 为 Air 增加 Windows `.exe` 构建和入口覆盖，同时保留 Linux/macOS 默认配置。

