### PR TITLE
修复「我的提交」加载更多清空列表

### DIFF
--- a/apps/web/app/components/edit/galgame/Mine.vue
+++ b/apps/web/app/components/edit/galgame/Mine.vue
@@ -1,13 +1,47 @@
 <script setup lang="ts">
-const pageData = reactive({
-  before: 0,
-  limit: 20
+const limit = 20
+
+const items = ref<UserClaimItem[]>([])
+const nextBefore = ref(0)
+const total = ref(0)
+const isLoadingMore = ref(false)
+
+const { data, refresh } = await useKunFetch<UserClaimList>('/galgame/mine', {
+  query: { before: 0, limit }
 })
 
-const { data, status, refresh } = await useKunFetch<UserClaimList>(
-  '/galgame/mine',
-  { query: pageData }
+watch(
+  data,
+  (page) => {
+    if (!page) {
+      return
+    }
+    items.value = page.items
+    nextBefore.value = page.next_before
+    total.value = page.total
+  },
+  { immediate: true }
 )
+
+const hasMore = computed(
+  () => nextBefore.value > 0 && items.value.length < total.value
+)
+
+const loadMore = async () => {
+  if (isLoadingMore.value || !hasMore.value) {
+    return
+  }
+  isLoadingMore.value = true
+  const next = await kunFetch<UserClaimList>(
+    `/galgame/mine?before=${nextBefore.value}&limit=${limit}`
+  )
+  isLoadingMore.value = false
+  if (!next) {
+    return
+  }
+  items.value.push(...next.items)
+  nextBefore.value = next.next_before
+}
 
 const stateBadge = galgameClaimStateBadge
 const nameOf = (item: UserClaimItem) => item.display_name || '(无标题)'
@@ -82,9 +116,9 @@ const handleResubmit = async (item: UserClaimItem) => {
       description="无法获取您的提交列表, 可能是后端 / Galgame 资料库暂时不可用, 请稍后重试。"
     />
 
-    <div v-else-if="data.items.length" class="flex flex-col gap-3">
+    <div v-else-if="items.length" class="flex flex-col gap-3">
       <div
-        v-for="item in data.items"
+        v-for="item in items"
         :key="item.work_id"
         class="dark:border-default-200 flex flex-col gap-3 rounded-lg border border-transparent p-3 backdrop-blur-none transition-all duration-200 sm:flex-row sm:items-center"
       >
@@ -149,13 +183,13 @@ const handleResubmit = async (item: UserClaimItem) => {
       </div>
     </div>
 
-    <KunNull v-else-if="data && !data.items.length" />
+    <KunNull v-else-if="data && !items.length" />
 
     <KunButton
-      v-if="data && data.next_before"
+      v-if="hasMore"
       variant="flat"
-      :loading="status === 'pending'"
-      @click="pageData.before = data.next_before"
+      :loading="isLoadingMore"
+      @click="loadMore"
     >
       加载更多
     </KunButton>


### PR DESCRIPTION
## 问题

https://www.kungal.com/update/todo 的待办之一：发布 Galgame 的「我的提交」界面，点击「加载更多」会使列表清空、变成"什么都没有"。

原实现把 `pageData.before` 直接改成 `next_before` 并整页刷新，跟随了短尾页仍然携带的游标，导致列表被清空。

## 修改

- 改为追加式分页：`items` 累积，`loadMore` 只在 `hasMore` 时追加下一页。
- `hasMore` 同时判断 `next_before > 0` 且 `items.length < total`，与后端"满页才带游标"的契约配合（依赖 infra 侧分页修复 KunMoe/kun-galgame-infra#10）。

## 说明

本 PR 只包含「加载更多」这一个 bug 的前端修复，与「我的审核」功能拆开（见配套 PR）。