### PR TITLE
新增「我的审核」列表，区分提交与审核

### DIFF
--- a/apps/api/internal/app/router.go
+++ b/apps/api/internal/app/router.go
@@ -106,6 +106,7 @@ func (a *App) setupRoutes() {
 	// catch-all binds "mine" / "calendar" / "drafts" as a gid and then fails
 	// inside GetDetail with Atoi("mine").
 	api.Get("/galgame/mine", userAuth, a.GalgameSubmissionHandler.ListMine)
+	api.Get("/galgame/myaudit", userAuth, a.GalgameSubmissionHandler.ListAudit)
 	api.Get(
 		"/galgame/search/wizard",
 		userAuth,

--- a/apps/api/internal/app/testdata/routes.golden
+++ b/apps/api/internal/app/testdata/routes.golden
@@ -98,6 +98,7 @@ GET    /api/galgame/collection/:cid                   cors.New → OptionalAuth 
 GET    /api/galgame/drafts                            cors.New → DraftsHandler.GetDrafts
 GET    /api/galgame/interactions/mine                 cors.New → OptionalAuth → Auth → GalgameHandler.MyInteractions
 GET    /api/galgame/mine                              cors.New → Auth → SubmissionHandler.ListMine
+GET    /api/galgame/myaudit                           cors.New → Auth → SubmissionHandler.ListAudit
 GET    /api/galgame/search/picker                     cors.New → QuizHandler.SearchGalgames
 GET    /api/galgame/search/wizard                     cors.New → Auth → SubmissionHandler.SearchWithPending
 GET    /api/home                                      cors.New → HomeHandler.GetHome

--- a/apps/api/internal/galgame/handler/submission_handler.go
+++ b/apps/api/internal/galgame/handler/submission_handler.go
@@ -106,6 +106,18 @@ func (h *SubmissionHandler) ListMine(c fiber.Ctx) error {
 	return response.OK(c, page)
 }
 
+func (h *SubmissionHandler) ListAudit(c fiber.Ctx) error {
+	token, appErr := userToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	page, appErr := h.svc.ListAudit(c.Context(), token, collectQuery(c))
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	return response.OK(c, page)
+}
+
 func (h *SubmissionHandler) SearchWithPending(c fiber.Ctx) error {
 	token, appErr := userToken(c)
 	if appErr != nil {

--- a/apps/api/internal/galgame/service/submission_service.go
+++ b/apps/api/internal/galgame/service/submission_service.go
@@ -185,6 +185,26 @@ func (s *SubmissionService) ListMine(
 		ClaimStates: states,
 		Before:      int64(atoiOr(query.Get("before"), 0)),
 		Limit:       atoiOr(query.Get("limit"), 20),
+		Kind:        "submitted",
+	})
+	if err != nil {
+		return nil, claimActionError(err)
+	}
+	if page.Items == nil {
+		page.Items = []catalogclient.UserClaimItem{}
+	}
+	return page, nil
+}
+
+func (s *SubmissionService) ListAudit(
+	ctx context.Context,
+	accessToken string,
+	query url.Values,
+) (*catalogclient.UserClaimPage, *errors.AppError) {
+	page, err := s.catalog.MyClaims(ctx, accessToken, catalogclient.UserClaimFilter{
+		Before: int64(atoiOr(query.Get("before"), 0)),
+		Limit:  atoiOr(query.Get("limit"), 20),
+		Kind:   "audited",
 	})
 	if err != nil {
 		return nil, claimActionError(err)

--- a/apps/api/pkg/catalogclient/claims.go
+++ b/apps/api/pkg/catalogclient/claims.go
@@ -105,6 +105,7 @@ type UserClaimFilter struct {
 	ClaimStates []string
 	Before      int64
 	Limit       int
+	Kind        string
 }
 
 func (c *Client) UserClaims(ctx context.Context, uid int64, f UserClaimFilter) (*UserClaimPage, error) {

--- a/apps/api/pkg/catalogclient/user_claims.go
+++ b/apps/api/pkg/catalogclient/user_claims.go
@@ -40,6 +40,9 @@ func (c *Client) MyClaims(ctx context.Context, accessToken string, f UserClaimFi
 	if f.Limit > 0 {
 		q.Set("limit", strconv.Itoa(f.Limit))
 	}
+	if f.Kind != "" {
+		q.Set("kind", f.Kind)
+	}
 	path := userClaimBase + "/claims/mine"
 	if len(q) > 0 {
 		path += "?" + q.Encode()

--- a/apps/web/app/components/edit/galgame/MineAudit.vue
+++ b/apps/web/app/components/edit/galgame/MineAudit.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+const limit = 20
+
+const items = ref<UserClaimItem[]>([])
+const nextBefore = ref(0)
+const total = ref(0)
+const isLoadingMore = ref(false)
+
+const { data, refresh } = await useKunFetch<UserClaimList>('/galgame/myaudit', {
+  query: { before: 0, limit }
+})
+
+watch(
+  data,
+  (page) => {
+    if (!page) {
+      return
+    }
+    items.value = page.items
+    nextBefore.value = page.next_before
+    total.value = page.total
+  },
+  { immediate: true }
+)
+
+const hasMore = computed(
+  () => nextBefore.value > 0 && items.value.length < total.value
+)
+
+const loadMore = async () => {
+  if (isLoadingMore.value || !hasMore.value) {
+    return
+  }
+  isLoadingMore.value = true
+  const next = await kunFetch<UserClaimList>(
+    `/galgame/myaudit?before=${nextBefore.value}&limit=${limit}`
+  )
+  isLoadingMore.value = false
+  if (!next) {
+    return
+  }
+  items.value.push(...next.items)
+  nextBefore.value = next.next_before
+}
+
+const stateBadge = galgameClaimStateBadge
+const nameOf = (item: UserClaimItem) => item.display_name || '(无标题)'
+const gidOf = (item: UserClaimItem) => item.product_work_id ?? item.work_id
+</script>
+
+<template>
+  <div class="space-y-4">
+    <KunHeader
+      name="我的 Galgame 审核"
+      description="您审核过的 Galgame 申请, 包括已通过 / 已拒绝 / 已下架的作品。"
+    />
+
+    <KunDivider />
+
+    <KunInfo
+      v-if="!data"
+      color="danger"
+      title="加载失败"
+      description="无法获取您的审核列表, 可能是后端 / Galgame 资料库暂时不可用, 请稍后重试。"
+    />
+
+    <div v-else-if="items.length" class="flex flex-col gap-3">
+      <div
+        v-for="item in items"
+        :key="item.work_id"
+        class="dark:border-default-200 flex flex-col gap-3 rounded-lg border border-transparent p-3 backdrop-blur-none transition-all duration-200 sm:flex-row sm:items-center"
+      >
+        <div class="min-w-0 flex-1 space-y-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <h3
+              class="hover:text-primary truncate text-lg font-medium transition-colors"
+            >
+              {{ nameOf(item) }}
+            </h3>
+            <KunChip
+              size="xs"
+              variant="flat"
+              :color="stateBadge(item.claim_state).color"
+            >
+              {{ stateBadge(item.claim_state).label }}
+            </KunChip>
+          </div>
+          <div
+            class="text-default-500 flex flex-wrap items-center gap-2 text-sm"
+          >
+            <span>首次审核 <KunTime :time="item.first_acted_at" /></span>
+            <template v-if="item.last_event_at !== item.first_acted_at">
+              <span>·</span>
+              <span>最后处理 <KunTime :time="item.last_event_at" /></span>
+            </template>
+          </div>
+          <div
+            v-if="item.last_reason"
+            class="text-default-500 bg-default-500/10 mt-1 rounded-md px-2 py-1 text-sm"
+          >
+            审核理由: {{ item.last_reason }}
+          </div>
+        </div>
+        <div class="flex shrink-0 gap-2">
+          <KunLink :to="`/galgame/${gidOf(item)}`">
+            <KunButton size="sm" variant="flat">查看</KunButton>
+          </KunLink>
+        </div>
+      </div>
+    </div>
+
+    <KunNull v-else-if="data && !items.length" />
+
+    <KunButton
+      v-if="hasMore"
+      variant="flat"
+      :loading="isLoadingMore"
+      @click="loadMore"
+    >
+      加载更多
+    </KunButton>
+  </div>
+</template>

--- a/apps/web/app/components/edit/galgame/Wizard.vue
+++ b/apps/web/app/components/edit/galgame/Wizard.vue
@@ -18,6 +18,7 @@ interface WizardSearchResp {
 }
 
 const q = ref('')
+const { canModerate } = useRole()
 const hasSearched = ref(false)
 const isSearching = ref(false)
 const searchResults = ref<WizardSearchResp | null>(null)
@@ -97,9 +98,14 @@ onMounted(() => {
       description="先搜索您想发布的游戏：已存在的直接前往或一键认领，确实没有的再新建申请，避免重复提交。"
     >
       <template #endContent>
-        <KunLink to="/edit/galgame/mine">
-          <KunButton size="sm" variant="flat">我的提交</KunButton>
-        </KunLink>
+        <div class="flex items-center gap-2">
+          <KunLink to="/edit/galgame/mine">
+            <KunButton size="sm" variant="flat">我的提交</KunButton>
+          </KunLink>
+          <KunLink v-if="canModerate" to="/edit/galgame/myaudit">
+            <KunButton size="sm" variant="flat">我的审核</KunButton>
+          </KunLink>
+        </div>
       </template>
     </KunHeader>
 

--- a/apps/web/app/pages/edit/galgame/myaudit.vue
+++ b/apps/web/app/pages/edit/galgame/myaudit.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: ['auth']
+})
+
+useKunDisableSeo('我的 Galgame 审核')
+</script>
+
+<template>
+  <EditGalgameMineAudit />
+</template>


### PR DESCRIPTION
## 问题

https://www.kungal.com/update/todo 的待办之一：发布 Galgame 的「我的提交」界面，被我拒绝的申请会出现在自己的提交列表里。

前端侧修复：把"自己提交的作品"与"自己审核过的作品"拆成两个列表——「我的提交」走 `kind=submitted`，「我的审核」走新增的 `kind=audited`。

## 修改

- BFF 新增 `GET /galgame/myaudit`（`SubmissionHandler.ListAudit` → `SubmissionService.ListAudit`），透传 `kind=audited`。
- `catalogclient` 的 `UserClaimFilter` 增加 `Kind`，并在 `MyClaims` 里透传 `kind` 查询参数。
- `Wizard.vue` 给有审核权限的用户（`canModerate`）增加「我的审核」入口。
- 新增 `MineAudit.vue`（审核列表组件）与 `myaudit.vue`（页面），展示审核过的作品、首次/最后处理时间与审核理由。

## 依赖关系（重要）

依赖 infra 侧 `kind` 过滤（KunMoe/kun-galgame-infra#11）。本侧的 `kind` 透传与 infra 侧的 `kind` 参数同属一个功能拆分，请先合并 infra 的 kind PR（#11）再合并本 PR。