### PR TITLE
fix(galgame): expose claim_state in the publish wizard search results

### DIFF
--- a/apps/api/internal/galgame/client/catalog_wire.go
+++ b/apps/api/internal/galgame/client/catalog_wire.go
@@ -314,8 +314,10 @@ func CatalogItemToBrief(it *CatalogWorkListItem) GalgameBrief {
 	}
 	if it.ClaimedBy != nil {
 		b.Status = statusFromClaimState(it.ClaimedBy.State)
+		b.ClaimState = it.ClaimedBy.State
 	} else {
 		b.Status = galgameStatusVndbDraft
+		b.ClaimState = claimStateDraft
 	}
 	b.VndbID = b.Refs["vndb"]
 	b.EffectiveBannerHash, b.EffectiveBannerURL,

--- a/apps/api/internal/galgame/client/client.go
+++ b/apps/api/internal/galgame/client/client.go
@@ -244,6 +244,7 @@ type GalgameBrief struct {
 	NameZhTw            string  `json:"name_zh_tw"`
 	Banner              string  `json:"banner"`
 	Status              int     `json:"status"`
+	ClaimState          string  `json:"claim_state,omitempty"`
 	ContentLimit        string  `json:"content_limit"`
 	UserID              int     `json:"user_id"`
 	OriginalLanguage    string  `json:"original_language"`

--- a/apps/api/internal/galgame/service/wizard_search_test.go
+++ b/apps/api/internal/galgame/service/wizard_search_test.go
@@ -120,6 +120,10 @@ func TestWizard_ItemsAreKeyedByGIDAndDropWithdrawnRows(t *testing.T) {
 	if page.Items[0].VndbID != "v22610" {
 		t.Errorf("vndb_id = %q, want v22610", page.Items[0].VndbID)
 	}
+	if page.Items[0].ClaimState != "live" || page.Items[1].ClaimState != "draft" {
+		t.Errorf("claim_state = %q,%q, want live,draft — the wizard branches on it",
+			page.Items[0].ClaimState, page.Items[1].ClaimState)
+	}
 	if page.Items[0].Banner == "" || page.Items[0].Banner != page.Items[0].EffectiveBannerURL {
 		t.Errorf("banner = %q, want it mirrored from effective_banner_url %q",
 			page.Items[0].Banner, page.Items[0].EffectiveBannerURL)


### PR DESCRIPTION
## Bug（问题）

在发布向导 `/edit/galgame/publish` 搜索到一个尚未发布的条目（VNDB 草稿，例如 v7341 / v475）时，操作按钮错误地显示为「前往发布资源」。点击后会跳转到 `/galgame/:gid` 详情页，由于该条目尚未发布，得到 404「该 Galgame 尚未发布」。

Searching the publish wizard `/edit/galgame/publish` for an unpublished entry (a VNDB draft, e.g. v7341 / v475) wrongly renders the action as "前往发布资源" (go publish resource). Clicking it navigates to `/galgame/:gid`, which 404s ("该 Galgame 尚未发布") because the entry has not been published yet.

## 原因（Root cause）

前端向导在 commit `c5717c2a` 中已迁移为按 `claim_state` 字符串分支（`draft` → 认领并发布 / `pending` → 审核中 / `live` → 前往发布资源），但后端搜索接口返回的 `GalgameBrief` 只序列化了整型 `status`（且把 draft/pending 都折叠成一个值），从未输出 `claim_state` 字段。因此前端读到的 `hit.claim_state` 恒为 `undefined`，所有命中都落入 `v-else` 分支，被当作已发布条目渲染成「前往发布资源」。

The frontend wizard was migrated (commit `c5717c2a`) to branch on the `claim_state` string (`draft` → claim / `pending` → under review / `live` → publish resource), but the search endpoint's `GalgameBrief` only serializes the integer `status` (collapsing draft/pending into one value) and never emitted a `claim_state` field. As a result `hit.claim_state` is always `undefined`, every hit falls through to the `v-else` branch, and drafts are rendered as published entries with "前往发布资源".

## 解决方式（Fix）

在 `GalgameBrief` 中新增 `claim_state` 字段，并在 `CatalogItemToBrief` 中透传 catalog 的 `claimed_by.state`（未认领的条目置为 `draft`）。前端因此能正确区分 `live` / `draft` / `pending`，草稿会显示「认领并发布」而不是跳转到会 404 的详情页。同时补充了防回归测试断言。

Add a `claim_state` field to `GalgameBrief` and populate it from the catalog's `claimed_by.state` in `CatalogItemToBrief` (unclaimed entries fall back to `draft`). The frontend now distinguishes `live` / `draft` / `pending` correctly, and drafts render "认领并发布" (claim) instead of linking to the 404 detail page. A regression test assertion was added.
