### PR TITLE
fix(galgame): scope the publish wizard's claim lists to actionable states

### DIFF
--- a/apps/api/internal/galgame/client/catalog_wire.go
+++ b/apps/api/internal/galgame/client/catalog_wire.go
@@ -238,6 +238,23 @@ func CatalogItemRenderable(it *CatalogWorkListItem) bool { return it.isRenderabl
 
 func CatalogItemGID(it *CatalogWorkListItem) int { return it.gid() }
 
+// CatalogItemWizardEligible reports whether a search row belongs in the
+// publish wizard's supply: a kungal claim whose live state is live, draft or
+// pending. The index's claim_state facet lags a decline until the next reindex,
+// so the facet filter alone lets a just-declined work through — its hydrated
+// state already reads "declined" while the index still says "pending".
+func CatalogItemWizardEligible(it *CatalogWorkListItem) bool {
+	if it.ClaimedBy == nil || !isKungalClaim(it.ClaimedBy.Site) {
+		return false
+	}
+	switch it.ClaimedBy.State {
+	case claimStateLive, claimStateDraft, claimStatePending:
+		return true
+	default:
+		return false
+	}
+}
+
 func (it *CatalogWorkListItem) gid() int {
 	if it.ClaimedBy == nil || !isKungalClaim(it.ClaimedBy.Site) {
 		return 0

--- a/apps/api/internal/galgame/service/submission_service.go
+++ b/apps/api/internal/galgame/service/submission_service.go
@@ -298,7 +298,7 @@ func (s *SubmissionService) wizardItems(
 	items := make([]client.GalgameBrief, 0, len(res.Items))
 	for i := range res.Items {
 		row := &res.Items[i]
-		if !client.CatalogItemRenderable(row) || client.CatalogItemGID(row) == 0 {
+		if !client.CatalogItemWizardEligible(row) {
 			continue
 		}
 		b := client.CatalogItemToBrief(row)
@@ -315,6 +315,7 @@ func (s *SubmissionService) wizardPending(
 	page, err := s.catalog.MyClaims(ctx, accessToken, catalogclient.UserClaimFilter{
 		ClaimStates: []string{catalogclient.ClaimStatePending, catalogclient.ClaimStateDeclined},
 		Limit:       wizardDefaultLimit,
+		Kind:        catalogclient.ClaimKindSubmitted,
 	})
 	if err != nil {
 		return nil, claimActionError(err)

--- a/apps/api/internal/galgame/service/wizard_search_test.go
+++ b/apps/api/internal/galgame/service/wizard_search_test.go
@@ -38,7 +38,9 @@ func (r *wizardRecorder) service(t *testing.T) *SubmissionService {
 			   "claimed_by":{"site":"kungal","work_id":9978,"state":"draft"}},
 			  {"id":13,"display_name":"withdrawn","cover":"",
 			   "claimed_by":{"site":"kungal","work_id":404,"state":"hidden"}},
-			  {"id":14,"display_name":"unclaimed","cover":"","claimed_by":null}
+			  {"id":14,"display_name":"unclaimed","cover":"","claimed_by":null},
+			  {"id":15,"display_name":"declined","cover":"",
+			   "claimed_by":{"site":"kungal","work_id":331,"state":"declined"}}
 			]}}`
 		case strings.Contains(req.URL.Path, "/claims"):
 			r.claimsQ = req.URL.Query()
@@ -112,7 +114,12 @@ func TestWizard_ItemsAreKeyedByGIDAndDropWithdrawnRows(t *testing.T) {
 	page := wizardSearch(t, rec.service(t))
 
 	if len(page.Items) != 2 {
-		t.Fatalf("items = %d, want 2 (hidden claim and unclaimed row are not actionable)", len(page.Items))
+		t.Fatalf("items = %d, want 2 (hidden, declined and unclaimed rows are not actionable)", len(page.Items))
+	}
+	for _, it := range page.Items {
+		if it.ClaimState == "declined" || it.ClaimState == "hidden" {
+			t.Errorf("item %d leaked with claim_state=%q — the wizard must drop non-live/draft/pending rows", it.ID, it.ClaimState)
+		}
 	}
 	if page.Items[0].ID != 292 || page.Items[1].ID != 9978 {
 		t.Errorf("ids = %d,%d, want the gids 292,9978", page.Items[0].ID, page.Items[1].ID)
@@ -151,6 +158,9 @@ func TestWizard_PendingComesFromThePerUserClaimFace(t *testing.T) {
 	}
 	if got := rec.claimsQ.Get("claim_state"); got != "pending,declined" {
 		t.Errorf("claim_state = %q, want pending,declined", got)
+	}
+	if got := rec.claimsQ.Get("kind"); got != "submitted" {
+		t.Errorf("kind = %q, want submitted — the wizard must list only the caller's own claims, not their reviews", got)
 	}
 	if len(page.Pending) != 1 || page.Pending[0].WorkID != 64689 {
 		t.Fatalf("pending = %+v, want the caller's own pending claim", page.Pending)


### PR DESCRIPTION
## Summary

`/edit/galgame/publish` 发布向导的搜索框下方有两个列表，此前都会把「无法操作」的投稿漏出来。本 PR 一并修掉：`pending` 区只显示本人提交，`items` 区只显示 `live` / `draft` / `pending`。

The `/edit/galgame/publish` wizard has two lists under its search box, and both leaked claims the UI has no action for. This PR fixes both: the pending strip lists only the caller's own submissions, and the items strip shows only `live` / `draft` / `pending`.

## Bug

1. 「您的待审 / 已拒草稿」列表会把用户触碰过的**所有** pending/declined 认领列出来 —— 审核者自己拒绝掉的别人投稿，也混在了自己的投稿旁边。
2. 「匹配的 Galgame」列表会显示**被拒绝**的投稿：刚被拒的作品仍出现在搜索结果里，带着「已拒绝」徽章和一个错误的「前往发布资源」链接。

1. The pending strip listed every pending/declined claim the caller had touched, so a reviewer's own declines — works they rejected for someone else — surfaced next to their own submissions.
2. The items strip showed declined submissions: a just-rejected work still appeared in the results, carrying a "已拒绝" badge and a wrong "前往发布资源" link.

## Root cause

1. `wizardPending` 调 catalog 的按用户认领接口时没有 owner 过滤，返回的是该用户「操作过」的所有认领（自己的提交 + 自己审核的别人投稿）。
2. `wizardItems` 只依赖搜索索引的 `claim_state` 过滤（`live,draft,pending`）来排除被拒作品；但索引要等下一次每日重建才会反映 decline。而结果行水合出的 `claimed_by.state` 是**实时**读库的 —— 所以刚被拒的作品能通过过期的索引过滤，却已经带着 `state=declined`，论坛侧又只丢弃 `hidden` / 未认领的行，于是它漏了出来。

1. `wizardPending` queried the catalog's per-user claim face with no owner filter, so it returned every claim the caller had acted on (own submissions *and* reviews).
2. `wizardItems` relied on the search index's `claim_state` facet (`live,draft,pending`) alone to exclude declined works, but that facet lags a decline until the next daily reindex. The row's hydrated `claimed_by.state`, however, is read live — so a just-declined work passed the stale index filter while already carrying `state=declined`; the forum only dropped `hidden`/unclaimed rows, so it leaked through.

## Fix

- `wizardPending` 增加 `kind=submitted`，只返回本人提交。
- `wizardItems` 改用新增的 `CatalogItemWizardEligible` 判定（基于水合出的实时状态，只放行 `live`/`draft`/`pending`）。

- Scope `wizardPending` to the caller's own submissions via `kind=submitted`.
- Gate `wizardItems` on the hydrated live state through a new `CatalogItemWizardEligible` helper that admits only `live`/`draft`/`pending`.

## Tests

- `TestWizard_PendingComesFromThePerUserClaimFace` 新增断言 `kind=submitted`。
- `TestWizard_ItemsAreKeyedByGIDAndDropWithdrawnRows` 的 mock 增加 `declined` 行，并断言 `declined` / `hidden` 均被丢弃。
