### PR TITLE
fix(galgame): claim and publish unclaimed VNDB works from the wizard

### DIFF
--- a/apps/api/internal/app/router.go
+++ b/apps/api/internal/app/router.go
@@ -263,6 +263,7 @@ func (a *App) setupRoutes() {
 	authed.Put("/website/:domain/favorite", a.WebsiteHandler.ToggleFavorite)
 
 	authed.Post("/galgame/submit", a.GalgameSubmissionHandler.Submit)
+	authed.Post("/galgame/work/:workId/claim", a.GalgameSubmissionHandler.ClaimUnclaimed)
 	authed.Post("/galgame/:gid/claim", a.GalgameSubmissionHandler.Claim)
 	authed.Post("/galgame/:gid/resubmit", a.GalgameSubmissionHandler.Resubmit)
 	authed.Delete("/galgame/:gid", a.GalgameSubmissionHandler.Withdraw)

--- a/apps/api/internal/app/testdata/routes.golden
+++ b/apps/api/internal/app/testdata/routes.golden
@@ -193,6 +193,7 @@ POST   /api/galgame/:gid/resubmit                     cors.New → OptionalAuth 
 POST   /api/galgame/collection                        cors.New → OptionalAuth → Auth → GalgameCollectionHandler.Create
 POST   /api/galgame/comments/:postId/flag             cors.New → OptionalAuth → Auth → CommunityCommentHandler.Flag
 POST   /api/galgame/submit                            cors.New → OptionalAuth → Auth → SubmissionHandler.Submit
+POST   /api/galgame/work/:workId/claim                cors.New → OptionalAuth → Auth → SubmissionHandler.ClaimUnclaimed
 POST   /api/image/cover                               cors.New → OptionalAuth → Auth → ImageHandler.UploadCoverImage
 POST   /api/image/galgame                             cors.New → OptionalAuth → Auth → ImageHandler.UploadGalgameImage
 POST   /api/image/message                             cors.New → OptionalAuth → Auth → ImageHandler.UploadMessageImage

--- a/apps/api/internal/galgame/client/catalog_wire.go
+++ b/apps/api/internal/galgame/client/catalog_wire.go
@@ -214,9 +214,12 @@ const (
 	claimStateDraft   = "draft"
 	claimStatePending = "pending"
 	claimStateHidden  = "hidden"
+	claimStateNone    = "none"
 )
 
 const ClaimStateWizard = claimStateLive + "," + claimStateDraft + "," + claimStatePending
+
+const ClaimStateWizardWithNone = claimStateLive + "," + claimStateDraft + "," + claimStatePending + "," + claimStateNone
 
 func statusFromClaimState(state string) int {
 	if state == claimStateLive {
@@ -237,6 +240,27 @@ func (it *CatalogWorkListItem) isRenderable() bool {
 func CatalogItemRenderable(it *CatalogWorkListItem) bool { return it.isRenderable() }
 
 func CatalogItemGID(it *CatalogWorkListItem) int { return it.gid() }
+
+// CatalogItemWizardEligible reports whether a search row belongs in the
+// publish wizard's supply: an unclaimed work (claimable) or a kungal claim
+// whose state is live, draft or pending. The index's claim_state facet lags a
+// decline until the next reindex, so the facet filter alone lets a
+// just-declined work through — its hydrated state already reads "declined"
+// while the index still says "pending".
+func CatalogItemWizardEligible(it *CatalogWorkListItem) bool {
+	if it.ClaimedBy == nil {
+		return true
+	}
+	if !isKungalClaim(it.ClaimedBy.Site) {
+		return false
+	}
+	switch it.ClaimedBy.State {
+	case claimStateLive, claimStateDraft, claimStatePending:
+		return true
+	default:
+		return false
+	}
+}
 
 func (it *CatalogWorkListItem) gid() int {
 	if it.ClaimedBy == nil || !isKungalClaim(it.ClaimedBy.Site) {
@@ -302,6 +326,7 @@ func coverFields(covers *catCoverSlots, fallbackURL string) (hash, url string, w
 func CatalogItemToBrief(it *CatalogWorkListItem) GalgameBrief {
 	b := GalgameBrief{
 		ID:               it.gid(),
+		WorkID:           it.ID,
 		NameEnUs:         it.name("en-us"),
 		NameJaJp:         it.name("ja-jp"),
 		NameZhCn:         it.name("zh-cn"),

--- a/apps/api/internal/galgame/client/client.go
+++ b/apps/api/internal/galgame/client/client.go
@@ -232,6 +232,7 @@ func BriefName(b *GalgameBrief) string {
 
 type GalgameBrief struct {
 	ID                  int     `json:"id"`
+	WorkID              int64   `json:"work_id"`
 	VndbID              string  `json:"vndb_id"`
 	NameEnUs            string  `json:"name_en_us"`
 	NameJaJp            string  `json:"name_ja_jp"`

--- a/apps/api/internal/galgame/handler/submission_handler.go
+++ b/apps/api/internal/galgame/handler/submission_handler.go
@@ -67,6 +67,26 @@ func (h *SubmissionHandler) Claim(c fiber.Ctx) error {
 	return response.OK(c, res)
 }
 
+func (h *SubmissionHandler) ClaimUnclaimed(c fiber.Ctx) error {
+	token, appErr := userToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	workID, parseErr := strconv.ParseInt(c.Params("workId"), 10, 64)
+	if parseErr != nil || workID <= 0 {
+		return response.Error(c, errors.ErrBadRequest("无效的 Galgame ID"))
+	}
+	user := middleware.GetUser(c)
+	if user == nil {
+		return response.Error(c, errors.ErrAuthExpired())
+	}
+	res, appErr := h.svc.ClaimUnclaimed(c.Context(), token, int64(user.ID), workID)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	return response.OK(c, res)
+}
+
 func (h *SubmissionHandler) Resubmit(c fiber.Ctx) error {
 	token, appErr := userToken(c)
 	if appErr != nil {

--- a/apps/api/internal/galgame/service/submission_service.go
+++ b/apps/api/internal/galgame/service/submission_service.go
@@ -112,6 +112,35 @@ func (s *SubmissionService) Claim(
 	return res, nil
 }
 
+// ClaimUnclaimed claims a bodyless catalog work (claim state "none") on behalf
+// of the user: it first adopts the work (claim: none → draft, anchoring it to
+// the forum via product_work_id = work id) and then publishes it (publish:
+// draft → live). The registry-issued work id becomes the forum gid, matching
+// what SubmitWork already does for brand-new submissions.
+func (s *SubmissionService) ClaimUnclaimed(
+	ctx context.Context,
+	accessToken string,
+	uid int64,
+	workID int64,
+) (*catalogclient.ClaimActionResult, *errors.AppError) {
+	if _, err := s.catalog.ActOnClaimUser(ctx, accessToken, workID, catalogclient.ClaimActionClaim, catalogclient.UserClaimActionRequest{
+		ProductWorkID: workID,
+	}); err != nil {
+		return nil, claimActionError(err)
+	}
+	res, err := s.catalog.ActOnClaimUser(ctx, accessToken, workID, catalogclient.ClaimActionPublish, catalogclient.UserClaimActionRequest{})
+	if err != nil {
+		return nil, claimActionError(err)
+	}
+	if err := s.galgameRepo.Touch(s.galgameRepo.DB().WithContext(ctx), int(workID)); err != nil {
+		slog.Warn("claim: 刷新本地 galgame resource_update_time 失败", "gid", workID, "error", err)
+	}
+	moemoepoint.Award(int(uid), constants.RewardCreateGalgame,
+		moemoepoint.ReasonContentApproved, moemoepoint.Ref("galgame", int(workID)),
+		moemoepoint.Key("claim", strconv.FormatInt(workID, 10), strconv.FormatInt(uid, 10)))
+	return res, nil
+}
+
 func (s *SubmissionService) Resubmit(
 	ctx context.Context,
 	accessToken string,
@@ -285,8 +314,7 @@ func (s *SubmissionService) wizardItems(
 		"q":           {query.Get("q")},
 		"page":        {strconv.Itoa(atoiOr(query.Get("page"), 1))},
 		"limit":       {strconv.Itoa(atoiOr(query.Get("limit"), wizardDefaultLimit))},
-		"claimed":     {"true"},
-		"claim_state": {client.ClaimStateWizard},
+		"claim_state": {client.ClaimStateWizardWithNone},
 		"include":     {wizardSearchInclude},
 	}
 	client.OpenPopulation(q)
@@ -298,7 +326,7 @@ func (s *SubmissionService) wizardItems(
 	items := make([]client.GalgameBrief, 0, len(res.Items))
 	for i := range res.Items {
 		row := &res.Items[i]
-		if !client.CatalogItemRenderable(row) || client.CatalogItemGID(row) == 0 {
+		if !client.CatalogItemWizardEligible(row) {
 			continue
 		}
 		b := client.CatalogItemToBrief(row)

--- a/apps/api/internal/galgame/service/wizard_search_test.go
+++ b/apps/api/internal/galgame/service/wizard_search_test.go
@@ -81,11 +81,11 @@ func TestWizard_ItemsComeFromTheCatalogSearch(t *testing.T) {
 	rec := &wizardRecorder{}
 	page := wizardSearch(t, rec.service(t))
 
-	if got := rec.catalogQ.Get("claim_state"); got != "live,draft,pending" {
-		t.Errorf("claim_state = %q, want live,draft,pending — `live` alone hides every unpublished entry", got)
+	if got := rec.catalogQ.Get("claim_state"); got != "live,draft,pending,none" {
+		t.Errorf("claim_state = %q, want live,draft,pending,none — `live` alone hides every unpublished entry, and omitting `none` hides the bodyless supply", got)
 	}
-	if got := rec.catalogQ.Get("claimed"); got != "true" {
-		t.Errorf("claimed = %q, want true — an unclaimed work has no gid to act on", got)
+	if got := rec.catalogQ.Get("claimed"); got != "" {
+		t.Errorf("claimed = %q, want it absent — the wizard must also surface unclaimed works", got)
 	}
 	if got := rec.catalogQ.Get("q"); got != "sakura" {
 		t.Errorf("q = %q, want sakura", got)
@@ -111,18 +111,21 @@ func TestWizard_ItemsAreKeyedByGIDAndDropWithdrawnRows(t *testing.T) {
 	rec := &wizardRecorder{}
 	page := wizardSearch(t, rec.service(t))
 
-	if len(page.Items) != 2 {
-		t.Fatalf("items = %d, want 2 (hidden claim and unclaimed row are not actionable)", len(page.Items))
+	if len(page.Items) != 3 {
+		t.Fatalf("items = %d, want 3 (only the hidden row is not actionable)", len(page.Items))
 	}
 	if page.Items[0].ID != 292 || page.Items[1].ID != 9978 {
 		t.Errorf("ids = %d,%d, want the gids 292,9978", page.Items[0].ID, page.Items[1].ID)
 	}
+	if page.Items[2].ID != 0 || page.Items[2].WorkID != 14 {
+		t.Errorf("unclaimed row = id %d work_id %d, want gid 0 + catalog work id 14", page.Items[2].ID, page.Items[2].WorkID)
+	}
 	if page.Items[0].VndbID != "v22610" {
 		t.Errorf("vndb_id = %q, want v22610", page.Items[0].VndbID)
 	}
-	if page.Items[0].ClaimState != "live" || page.Items[1].ClaimState != "draft" {
-		t.Errorf("claim_state = %q,%q, want live,draft — the wizard branches on it",
-			page.Items[0].ClaimState, page.Items[1].ClaimState)
+	if page.Items[0].ClaimState != "live" || page.Items[1].ClaimState != "draft" || page.Items[2].ClaimState != "draft" {
+		t.Errorf("claim_state = %q,%q,%q, want live,draft,draft — the wizard branches on it",
+			page.Items[0].ClaimState, page.Items[1].ClaimState, page.Items[2].ClaimState)
 	}
 	if page.Items[0].Banner == "" || page.Items[0].Banner != page.Items[0].EffectiveBannerURL {
 		t.Errorf("banner = %q, want it mirrored from effective_banner_url %q",

--- a/apps/web/app/components/edit/galgame/Wizard.vue
+++ b/apps/web/app/components/edit/galgame/Wizard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 interface SearchHit {
   id: number
+  work_id?: number
   vndb_id?: string
   name_zh_cn?: string
   name_ja_jp?: string
@@ -45,22 +46,27 @@ const handleSearch = async () => {
 
 const isClaiming = ref(false)
 
-const handleClaim = async (gid: number) => {
+const handleClaim = async (hit: SearchHit) => {
   const ok = await useComponentMessageStore().alert(
     '认领此草稿吗?',
     '认领后该条目立即变为已发布状态, 您将成为该 Galgame 的创建者, 并获得 +3 萌萌点。若该条目其实是他人正在审核中的投稿, 认领会被拒绝。'
   )
   if (!ok) return
 
+  const unclaimed = hit.id === 0
+  const endpoint = unclaimed
+    ? `/galgame/work/${hit.work_id}/claim`
+    : `/galgame/${hit.id}/claim`
+
   isClaiming.value = true
-  const result = await kunFetch<{ to_state: string }>(`/galgame/${gid}/claim`, {
+  const result = await kunFetch<{ to_state: string }>(endpoint, {
     method: 'POST',
     body: {}
   })
   isClaiming.value = false
   if (result?.to_state) {
     useKunLoliInfo('认领成功, 已发布', 5)
-    await navigateTo(`/galgame/${gid}`)
+    await navigateTo(`/galgame/${unclaimed ? hit.work_id : hit.id}`)
   }
 }
 
@@ -206,7 +212,7 @@ onMounted(() => {
             size="sm"
             :loading="isClaiming"
             :disabled="isClaiming"
-            @click="handleClaim(hit.id)"
+            @click="handleClaim(hit)"
           >
             认领并发布
           </KunButton>


### PR DESCRIPTION
## 中文

### 问题（Bug）
在发布向导（`/edit/galgame/publish`）中，VNDB 已收录、但本站尚未认领的游戏（bodyless / claim_state = `none`）搜不到，也认领不了。例如搜索 `v67921`（《EMIT: 逆时相拥》）没有任何结果。

### 出现原因
发布向导的搜索请求固定带 `claimed=true`，且 `claim_state` 只含 `live,draft,pending`，把未认领条目（`none`）直接排除在外；同时论坛侧只有 `publish`（`draft → live`）这一条认领动作，没有任何入口能对 `none` 条目执行 catalog 的 `claim`（`none → draft`）动作。

### 解决方式
1. 搜索：去掉 `claimed=true`，`claim_state` 扩展为 `live,draft,pending,none`，并让 `CatalogItemWizardEligible` 接受未认领条目。
2. 认领：新增 `ClaimUnclaimed` 服务/处理器/路由 `POST /galgame/work/:workId/claim`，先 `claim`（`none → draft`，以 catalog work id 作为 `product_work_id`）再 `publish`（`draft → live`）。
3. 前端：`GalgameBrief` 透出 `work_id`，`Wizard.vue` 对未认领条目（`id === 0`）改走新认领接口。

## English

### Bug
In the publish wizard (`/edit/galgame/publish`), VNDB games that are already in the catalog but not yet claimed on this site (bodyless / claim_state = `none`) cannot be searched or claimed. Searching `v67921` (EMIT: Embrace Beyond Time) returns nothing.

### Root cause
The wizard search hard-codes `claimed=true` with `claim_state` limited to `live,draft,pending`, which excludes unclaimed (`none`) works. Meanwhile the forum only exposes the `publish` (`draft → live`) claim action and has no path to run the catalog's `claim` (`none → draft`) action.

### Solution
1. Search: drop `claimed=true`, widen `claim_state` to `live,draft,pending,none`, and let `CatalogItemWizardEligible` accept unclaimed rows.
2. Claim: add a `ClaimUnclaimed` service/handler and route `POST /galgame/work/:workId/claim` that runs `claim` (`none → draft`, anchoring the registry work id as `product_work_id`) then `publish` (`draft → live`).
3. Frontend: expose `work_id` on `GalgameBrief`; `Wizard.vue` routes unclaimed hits (`id === 0`) to the new claim endpoint.
