### PR TITLE
feat(update): todo task board with claim/complete/discard flow

### DIFF
--- a/apps/api/internal/admin/model/admin.go
+++ b/apps/api/internal/admin/model/admin.go
@@ -23,7 +23,8 @@ type Todo struct {
 	Content       string     `gorm:"column:content;type:text;default:''" json:"content"`
 	CompletedTime *time.Time `gorm:"column:completed_time" json:"completed_time"`
 
-	UserID int `gorm:"column:user_id;not null" json:"user_id"`
+	ClaimedUserID *int `gorm:"column:claimed_user_id" json:"claimed_user_id"`
+	UserID        int  `gorm:"column:user_id;not null" json:"user_id"`
 
 	CreatedAt time.Time `gorm:"column:created" json:"created"`
 	UpdatedAt time.Time `gorm:"column:updated" json:"updated"`

--- a/apps/api/internal/app/app.go
+++ b/apps/api/internal/app/app.go
@@ -505,7 +505,7 @@ func New(cfg *config.Config) *App {
 		WebsiteHandler:                 websiteHandler.NewWebsiteHandler(websiteCoreSvc),
 		WebsiteCategoryHandler:         websiteHandler.NewCategoryHandler(websiteCategorySvc),
 		WebsiteTagHandler:              websiteHandler.NewTagHandler(websiteTagSvc),
-		UpdateHandler:                  updateHandler.NewUpdateHandler(updateRepo.NewUpdateRepository(db)),
+		UpdateHandler:                  updateHandler.NewUpdateHandler(updateRepo.NewUpdateRepository(db), uc),
 		FriendLinkHandler:              friendHandler.NewFriendLinkHandler(friendRepo.NewFriendLinkRepository(db), cfg.NextMoeAPI.ImageCDNBase),
 		TrustHandler:                   trustHandler.NewTrustHandler(trustService.NewTrustService(trustCli, cfg.Trust.Site), trustEnforce, cfg.Trust.CallbackSecret),
 		RSSHandler:                     rssHandler.NewRSSHandler(rssRepo.NewRSSRepository(db), gc, uc),

--- a/apps/api/internal/app/router.go
+++ b/apps/api/internal/app/router.go
@@ -398,9 +398,15 @@ func (a *App) setupRoutes() {
 	updateAdmin.Post("/update/history", middleware.RequirePermission(perm.UpdateLogCreate), a.UpdateHandler.CreateHistory)
 	updateAdmin.Put("/update/history", middleware.RequirePermission(perm.UpdateLogEdit), a.UpdateHandler.UpdateHistory)
 	updateAdmin.Delete("/update/history", middleware.RequirePermission(perm.UpdateLogDelete), a.UpdateHandler.DeleteHistory)
-	updateAdmin.Post("/update/todo", middleware.RequirePermission(perm.UpdateLogCreate), a.UpdateHandler.CreateTodo)
-	updateAdmin.Put("/update/todo", middleware.RequirePermission(perm.UpdateLogEdit), a.UpdateHandler.UpdateTodo)
+	updateAdmin.Post("/update/todo/claim", middleware.RequirePermission(perm.UpdateLogEdit), a.UpdateHandler.ClaimTodo)
 	updateAdmin.Delete("/update/todo", middleware.RequirePermission(perm.UpdateLogDelete), a.UpdateHandler.DeleteTodo)
+
+	// Creating, editing, completing and discarding a todo are open to any
+	// logged-in user; ownership is enforced in the handlers.
+	authed.Post("/update/todo", a.UpdateHandler.CreateTodo)
+	authed.Put("/update/todo", a.UpdateHandler.UpdateTodo)
+	authed.Post("/update/todo/complete", a.UpdateHandler.CompleteTodo)
+	authed.Post("/update/todo/discard", a.UpdateHandler.DiscardTodo)
 
 	friendAdmin := authed.Group("")
 	friendAdmin.Post("/admin/friend-link", middleware.RequirePermission(perm.FriendLinkCreate), a.FriendLinkHandler.Create)

--- a/apps/api/internal/app/testdata/routes.golden
+++ b/apps/api/internal/app/testdata/routes.golden
@@ -215,7 +215,10 @@ POST   /api/topic/:tid/reply                          cors.New → middleware.Na
 POST   /api/topic/draft                               cors.New → middleware.NamePreference → OptionalAuth → Auth → TopicDraftHandler.Save
 POST   /api/trust/callback                            cors.New → middleware.NamePreference → TrustHandler.Callback
 POST   /api/update/history                            cors.New → middleware.NamePreference → OptionalAuth → Auth → RequirePermission → UpdateHandler.CreateHistory
-POST   /api/update/todo                               cors.New → middleware.NamePreference → OptionalAuth → Auth → RequirePermission → UpdateHandler.CreateTodo
+POST   /api/update/todo                               cors.New → middleware.NamePreference → OptionalAuth → Auth → UpdateHandler.CreateTodo
+POST   /api/update/todo/claim                         cors.New → middleware.NamePreference → OptionalAuth → Auth → RequirePermission → UpdateHandler.ClaimTodo
+POST   /api/update/todo/complete                      cors.New → middleware.NamePreference → OptionalAuth → Auth → UpdateHandler.CompleteTodo
+POST   /api/update/todo/discard                       cors.New → middleware.NamePreference → OptionalAuth → Auth → UpdateHandler.DiscardTodo
 POST   /api/user/avatar                               cors.New → middleware.NamePreference → Auth → ProfileHandler.UploadAvatar
 POST   /api/user/check-in                             cors.New → middleware.NamePreference → Auth → UserHandler.CheckIn
 POST   /api/user/creator/apply                        cors.New → middleware.NamePreference → Auth → CreatorHandler.Apply
@@ -268,7 +271,7 @@ PUT    /api/topic/:tid/reply/pin                      cors.New → middleware.Na
 PUT    /api/topic/:tid/reply/reaction                 cors.New → middleware.NamePreference → OptionalAuth → Auth → ReplyHandler.ToggleReplyReaction
 PUT    /api/topic/:tid/upvote                         cors.New → middleware.NamePreference → OptionalAuth → Auth → TopicHandler.Upvote
 PUT    /api/update/history                            cors.New → middleware.NamePreference → OptionalAuth → Auth → RequirePermission → UpdateHandler.UpdateHistory
-PUT    /api/update/todo                               cors.New → middleware.NamePreference → OptionalAuth → Auth → RequirePermission → UpdateHandler.UpdateTodo
+PUT    /api/update/todo                               cors.New → middleware.NamePreference → OptionalAuth → Auth → UpdateHandler.UpdateTodo
 PUT    /api/user/bio                                  cors.New → middleware.NamePreference → Auth → ProfileHandler.UpdateBio
 PUT    /api/user/notification-preferences             cors.New → middleware.NamePreference → Auth → UserHandler.UpdateNotificationPreferences
 PUT    /api/user/username                             cors.New → middleware.NamePreference → Auth → ProfileHandler.UpdateUsername

--- a/apps/api/internal/update/dto/update_dto.go
+++ b/apps/api/internal/update/dto/update_dto.go
@@ -1,5 +1,21 @@
 package dto
 
+import (
+	adminModel "kun-galgame-api/internal/admin/model"
+)
+
+type UserBrief struct {
+	ID     int    `json:"id"`
+	Name   string `json:"name"`
+	Avatar string `json:"avatar"`
+}
+
+type TodoItem struct {
+	adminModel.Todo
+	User        UserBrief  `json:"user"`
+	ClaimedUser *UserBrief `json:"claimed_user,omitempty"`
+}
+
 type ListQuery struct {
 	Page  int `query:"page" validate:"min=1"`
 	Limit int `query:"limit" validate:"min=1,max=50"`
@@ -41,6 +57,9 @@ type UpdateHistoryRequest struct {
 type UpdateTodoRequest struct {
 	ID      int    `json:"todo_id" validate:"required,min=1"`
 	Type    string `json:"type" validate:"required"`
-	Status  int    `json:"status" validate:"min=0,max=10"`
 	Content string `json:"content" validate:"max=1000"`
+}
+
+type TodoActionRequest struct {
+	TodoID int `json:"todo_id" validate:"required,min=1"`
 }

--- a/apps/api/internal/update/handler/update_handler.go
+++ b/apps/api/internal/update/handler/update_handler.go
@@ -1,25 +1,25 @@
 package handler
 
 import (
-	"time"
-
 	adminModel "kun-galgame-api/internal/admin/model"
 	"kun-galgame-api/internal/middleware"
 	"kun-galgame-api/internal/update/dto"
 	"kun-galgame-api/internal/update/repository"
 	"kun-galgame-api/pkg/errors"
 	"kun-galgame-api/pkg/response"
+	"kun-galgame-api/pkg/userclient"
 	"kun-galgame-api/pkg/utils"
 
 	"github.com/gofiber/fiber/v3"
 )
 
 type UpdateHandler struct {
-	repo *repository.UpdateRepository
+	repo       *repository.UpdateRepository
+	userClient *userclient.Client
 }
 
-func NewUpdateHandler(repo *repository.UpdateRepository) *UpdateHandler {
-	return &UpdateHandler{repo: repo}
+func NewUpdateHandler(repo *repository.UpdateRepository, userClient *userclient.Client) *UpdateHandler {
+	return &UpdateHandler{repo: repo, userClient: userClient}
 }
 
 func (h *UpdateHandler) GetHistory(c fiber.Ctx) error {
@@ -104,8 +104,31 @@ func (h *UpdateHandler) GetTodos(c fiber.Ctx) error {
 	todos := h.repo.FindTodosPaginated(req.Page, req.Limit, req.Status)
 	total := h.repo.CountTodos(req.Status)
 
+	uids := userclient.CollectIDs(todos, func(t adminModel.Todo) int { return t.UserID })
+	for _, t := range todos {
+		if t.ClaimedUserID != nil {
+			uids = append(uids, *t.ClaimedUserID)
+		}
+	}
+	userMap := h.userClient.Hydrate(c.Context(), uids)
+
+	items := make([]dto.TodoItem, 0, len(todos))
+	for _, t := range todos {
+		u := userMap[t.UserID]
+		item := dto.TodoItem{
+			Todo: t,
+			User: dto.UserBrief{ID: u.ID, Name: u.Name, Avatar: u.Avatar},
+		}
+		if t.ClaimedUserID != nil {
+			if cu, ok := userMap[*t.ClaimedUserID]; ok {
+				item.ClaimedUser = &dto.UserBrief{ID: cu.ID, Name: cu.Name, Avatar: cu.Avatar}
+			}
+		}
+		items = append(items, item)
+	}
+
 	return response.OK(c, fiber.Map{
-		"todos": todos,
+		"todos": items,
 		"total": total,
 	})
 }
@@ -133,7 +156,8 @@ func (h *UpdateHandler) CreateTodo(c fiber.Ctx) error {
 }
 
 func (h *UpdateHandler) UpdateTodo(c fiber.Ctx) error {
-	if _, appErr := middleware.MustGetUser(c); appErr != nil {
+	user, appErr := middleware.MustGetUser(c)
+	if appErr != nil {
 		return response.Error(c, appErr)
 	}
 
@@ -142,20 +166,111 @@ func (h *UpdateHandler) UpdateTodo(c fiber.Ctx) error {
 		return response.Error(c, appErr)
 	}
 
+	todo, err := h.repo.FindTodoByID(req.ID)
+	if err != nil {
+		return response.Error(c, errors.ErrNotFound("待办不存在"))
+	}
+	if todo.UserID != user.ID {
+		return response.Error(c, errors.ErrForbidden("只有发起者可以编辑该待办"))
+	}
+	if todo.Status == 2 || todo.Status == 3 {
+		return response.Error(c, errors.ErrForbidden("已完成或已废弃的待办不可编辑"))
+	}
+
 	fields := map[string]any{
 		"type":    req.Type,
-		"status":  req.Status,
 		"content": req.Content,
-	}
-	if req.Status == 2 {
-		fields["completed_time"] = time.Now()
-	} else {
-		fields["completed_time"] = nil
 	}
 	if err := h.repo.UpdateTodo(req.ID, fields); err != nil {
 		return response.Error(c, errors.ErrInternal("更新待办失败"))
 	}
 	return response.OKMessage(c, "待办已更新")
+}
+
+func (h *UpdateHandler) ClaimTodo(c fiber.Ctx) error {
+	user, appErr := middleware.MustGetUser(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+
+	var req dto.TodoActionRequest
+	if appErr := utils.ParseAndValidate(c, &req); appErr != nil {
+		return response.Error(c, appErr)
+	}
+
+	todo, err := h.repo.FindTodoByID(req.TodoID)
+	if err != nil {
+		return response.Error(c, errors.ErrNotFound("待办不存在"))
+	}
+	if todo.Status != 0 {
+		return response.Error(c, errors.ErrForbidden("该待办已被认领或已结束"))
+	}
+	if err := h.repo.ClaimTodo(req.TodoID, user.ID); err != nil {
+		return response.Error(c, errors.ErrInternal("认领待办失败"))
+	}
+	return response.OKMessage(c, "已认领该待办")
+}
+
+func (h *UpdateHandler) CompleteTodo(c fiber.Ctx) error {
+	user, appErr := middleware.MustGetUser(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+
+	var req dto.TodoActionRequest
+	if appErr := utils.ParseAndValidate(c, &req); appErr != nil {
+		return response.Error(c, appErr)
+	}
+
+	todo, err := h.repo.FindTodoByID(req.TodoID)
+	if err != nil {
+		return response.Error(c, errors.ErrNotFound("待办不存在"))
+	}
+	if todo.Status != 1 {
+		return response.Error(c, errors.ErrForbidden("该待办未处于进行中状态"))
+	}
+	if todo.ClaimedUserID == nil || *todo.ClaimedUserID != user.ID {
+		return response.Error(c, errors.ErrForbidden("只有认领者可以完成该待办"))
+	}
+	if err := h.repo.CompleteTodo(req.TodoID); err != nil {
+		return response.Error(c, errors.ErrInternal("完成待办失败"))
+	}
+	return response.OKMessage(c, "待办已完成")
+}
+
+func (h *UpdateHandler) DiscardTodo(c fiber.Ctx) error {
+	user, appErr := middleware.MustGetUser(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+
+	var req dto.TodoActionRequest
+	if appErr := utils.ParseAndValidate(c, &req); appErr != nil {
+		return response.Error(c, appErr)
+	}
+
+	todo, err := h.repo.FindTodoByID(req.TodoID)
+	if err != nil {
+		return response.Error(c, errors.ErrNotFound("待办不存在"))
+	}
+
+	switch todo.Status {
+	case 0:
+		if todo.UserID != user.ID {
+			return response.Error(c, errors.ErrForbidden("只有发起者可以废弃该待办"))
+		}
+	case 1:
+		if todo.ClaimedUserID == nil || *todo.ClaimedUserID != user.ID {
+			return response.Error(c, errors.ErrForbidden("只有认领者可以废弃该待办"))
+		}
+	default:
+		return response.Error(c, errors.ErrForbidden("该待办不可废弃"))
+	}
+
+	if err := h.repo.DiscardTodo(req.TodoID); err != nil {
+		return response.Error(c, errors.ErrInternal("废弃待办失败"))
+	}
+	return response.OKMessage(c, "待办已废弃")
 }
 
 func (h *UpdateHandler) DeleteTodo(c fiber.Ctx) error {

--- a/apps/api/internal/update/repository/update_repo.go
+++ b/apps/api/internal/update/repository/update_repo.go
@@ -73,6 +73,30 @@ func (r *UpdateRepository) CreateTodo(todo *adminModel.Todo) error {
 	return r.db.Create(todo).Error
 }
 
+func (r *UpdateRepository) FindTodoByID(id int) (*adminModel.Todo, error) {
+	var todo adminModel.Todo
+	err := r.db.First(&todo, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &todo, nil
+}
+
+func (r *UpdateRepository) ClaimTodo(id, userID int) error {
+	return r.db.Model(&adminModel.Todo{}).Where("id = ?", id).
+		Updates(map[string]any{"status": 1, "claimed_user_id": userID}).Error
+}
+
+func (r *UpdateRepository) CompleteTodo(id int) error {
+	return r.db.Model(&adminModel.Todo{}).Where("id = ?", id).
+		Updates(map[string]any{"status": 2, "completed_time": time.Now()}).Error
+}
+
+func (r *UpdateRepository) DiscardTodo(id int) error {
+	return r.db.Model(&adminModel.Todo{}).Where("id = ?", id).
+		Updates(map[string]any{"status": 3, "completed_time": nil}).Error
+}
+
 func (r *UpdateRepository) UpdateTodo(id int, fields map[string]any) error {
 	return r.db.Model(&adminModel.Todo{}).Where("id = ?", id).
 		Updates(fields).Error

--- a/apps/api/migrations/075_todo_claimed_user.down.sql
+++ b/apps/api/migrations/075_todo_claimed_user.down.sql
@@ -1,0 +1,6 @@
+-- 075 down: drop the claimer column.
+BEGIN;
+
+ALTER TABLE todo DROP COLUMN IF EXISTS claimed_user_id;
+
+COMMIT;

--- a/apps/api/migrations/075_todo_claimed_user.up.sql
+++ b/apps/api/migrations/075_todo_claimed_user.up.sql
@@ -1,0 +1,12 @@
+-- 075: record who claimed a todo entry.
+--
+-- The todo list becomes a small task board: a pending entry (status 0) can be
+-- claimed by a user with update_log.edit (status 0 -> 1), and only that claimer
+-- may then complete (1 -> 2) or discard (1 -> 3) it. claimed_user_id holds the
+-- claimer's user id so the list can render "已被 X 认领" and gate the
+-- complete/discard buttons.
+BEGIN;
+
+ALTER TABLE todo ADD COLUMN IF NOT EXISTS claimed_user_id integer;
+
+COMMIT;

--- a/apps/api/migrations/076_feed_update_links.down.sql
+++ b/apps/api/migrations/076_feed_update_links.down.sql
@@ -1,0 +1,24 @@
+-- 076 down: restore the '/update' feed links.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION feed_sync_todo() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN PERFORM feed_delete('TODO_CREATION', OLD.id); RETURN OLD; END IF;
+    PERFORM feed_upsert('TODO_CREATION', NEW.id, NEW.user_id, 0, NEW.content, '/update', false, NEW.created);
+    RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION feed_sync_update_log() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN PERFORM feed_delete('UPDATE_LOG_CREATION', OLD.id); RETURN OLD; END IF;
+    PERFORM feed_upsert('UPDATE_LOG_CREATION', NEW.id, NEW.user_id, 0, NEW.content, '/update', false, NEW.created);
+    RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+UPDATE feed_activity SET link = '/update'
+WHERE type = 'TODO_CREATION' AND link = '/update/todo';
+
+UPDATE feed_activity SET link = '/update'
+WHERE type = 'UPDATE_LOG_CREATION' AND link = '/update/history';
+
+COMMIT;

--- a/apps/api/migrations/076_feed_update_links.up.sql
+++ b/apps/api/migrations/076_feed_update_links.up.sql
@@ -1,0 +1,29 @@
+-- 076: point the todo / update_log feed links at their real pages.
+--
+-- Since 034 (and untouched by 074) both feed triggers wrote '/update' as the
+-- link. '/update' is the section shell and had no index page, so a todo or
+-- update-log card on the home "其他" feed jumped to an empty page. The todo
+-- board now lives at /update/todo and the changelog at /update/history.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION feed_sync_todo() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN PERFORM feed_delete('TODO_CREATION', OLD.id); RETURN OLD; END IF;
+    PERFORM feed_upsert('TODO_CREATION', NEW.id, NEW.user_id, 0, NEW.content, '/update/todo', false, NEW.created);
+    RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION feed_sync_update_log() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN PERFORM feed_delete('UPDATE_LOG_CREATION', OLD.id); RETURN OLD; END IF;
+    PERFORM feed_upsert('UPDATE_LOG_CREATION', NEW.id, NEW.user_id, 0, NEW.content, '/update/history', false, NEW.created);
+    RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+UPDATE feed_activity SET link = '/update/todo'
+WHERE type = 'TODO_CREATION' AND link = '/update';
+
+UPDATE feed_activity SET link = '/update/history'
+WHERE type = 'UPDATE_LOG_CREATION' AND link = '/update';
+
+COMMIT;

--- a/apps/web/app/components/update/Todo.vue
+++ b/apps/web/app/components/update/Todo.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import {
   KUN_TODO_TYPE_MAP,
   KUN_UPDATE_LOG_STATUS_MAP
 } from '~/constants/update'
-import type { UpdateTodoPayload } from './types'
+import type { TodoSubmitPayload, UpdateTodoPayload } from './types'
 
-const canCreateUpdateLog = useCan('update_log.create')
+const { id: userId } = storeToRefs(usePersistUserStore())
+
 const canEditUpdateLog = useCan('update_log.edit')
 
 const iconMap: Record<number, string> = {
@@ -48,10 +50,20 @@ const { data, status, refresh } = await useKunFetch<UpdateTodoList>(
   { query: pageData }
 )
 
+const isCreator = (todo: UpdateTodo) => todo.user_id === userId.value
+
+const isClaimer = (todo: UpdateTodo) =>
+  todo.claimed_user_id !== null &&
+  todo.claimed_user_id !== undefined &&
+  todo.claimed_user_id === userId.value
+
 const showTodoModal = ref(false)
 const editingTodo = ref<UpdateTodoPayload>({} as UpdateTodoPayload)
 
 const openCreateTodoModal = () => {
+  if (!requireLogin()) {
+    return
+  }
   editingTodo.value = {} as UpdateTodoPayload
   showTodoModal.value = true
 }
@@ -61,15 +73,14 @@ const openEditTodoModal = (log: UpdateTodo) => {
     return
   }
   editingTodo.value = {
-    status: log.status,
-    type: 'forum',
+    type: log.type as UpdateTodoPayload['type'],
     content: log.content,
     todo_id: log.id
   } satisfies UpdateTodoPayload
   showTodoModal.value = true
 }
 
-const handleTodoAction = async (data: UpdateTodoPayload) => {
+const handleTodoAction = async (data: TodoSubmitPayload) => {
   const result = await kunFetch('/update/todo', {
     method: data.todo_id ? 'PUT' : 'POST',
     body: data
@@ -77,6 +88,42 @@ const handleTodoAction = async (data: UpdateTodoPayload) => {
 
   if (result) {
     useMessage(data.todo_id ? '更新成功' : '发布待办成功', 'success')
+    refresh()
+  }
+}
+
+const claimTodo = async (todo: UpdateTodo) => {
+  const result = await kunFetch('/update/todo/claim', {
+    method: 'POST',
+    body: { todo_id: todo.id }
+  })
+
+  if (result) {
+    useMessage('已认领该待办', 'success')
+    refresh()
+  }
+}
+
+const completeTodo = async (todo: UpdateTodo) => {
+  const result = await kunFetch('/update/todo/complete', {
+    method: 'POST',
+    body: { todo_id: todo.id }
+  })
+
+  if (result) {
+    useMessage('待办已完成', 'success')
+    refresh()
+  }
+}
+
+const discardTodo = async (todo: UpdateTodo) => {
+  const result = await kunFetch('/update/todo/discard', {
+    method: 'POST',
+    body: { todo_id: todo.id }
+  })
+
+  if (result) {
+    useMessage('待办已废弃', 'success')
     refresh()
   }
 }
@@ -89,7 +136,7 @@ const handleTodoAction = async (data: UpdateTodoPayload) => {
       description="这里记录了网站将会实现的功能, 以及更改的功能, 包括 Galgame 以及话题, 以及网站所有方向可能发生的各种更新等等"
     >
       <template #endContent>
-        <div v-if="canCreateUpdateLog" class="flex justify-end">
+        <div class="flex justify-end">
           <KunButton @click="openCreateTodoModal">创建待办</KunButton>
         </div>
       </template>
@@ -127,14 +174,36 @@ const handleTodoAction = async (data: UpdateTodoPayload) => {
       :key="todo.id"
       content-class="space-y-3"
     >
-      <div class="flex items-center gap-3">
-        <KunChip color="primary">
-          {{ KUN_TODO_TYPE_MAP[todo.type] }}
-        </KunChip>
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-3">
+          <KunChip color="primary">
+            {{ KUN_TODO_TYPE_MAP[todo.type] }}
+          </KunChip>
 
-        <span class="text-default-600 text-sm">
-          该企划创建于 <KunTime :time="todo.created" type="datetime" />
-        </span>
+          <span class="text-default-600 text-sm">
+            该企划创建于 <KunTime :time="todo.created" type="datetime" />
+          </span>
+        </div>
+
+        <div
+          v-if="todo.status === 1 && todo.claimed_user"
+          class="text-default-500 flex items-center gap-2 text-sm"
+        >
+          <KunAvatar :user="todo.claimed_user" size="xs" :is-navigation="false" />
+          <span>已被 {{ todo.claimed_user.name }} 认领</span>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <KunAvatar :user="todo.user" size="sm" />
+        <KunLink
+          color="default"
+          underline="hover"
+          :to="`/user/${todo.user.id}`"
+          class-name="text-sm"
+        >
+          {{ todo.user.name }}
+        </KunLink>
       </div>
 
       <pre class="font-mono break-all whitespace-pre-line">
@@ -155,14 +224,44 @@ const handleTodoAction = async (data: UpdateTodoPayload) => {
           </span>
         </div>
 
-        <KunButton
-          variant="flat"
-          size="sm"
-          v-if="canEditUpdateLog"
-          @click="openEditTodoModal(todo)"
-        >
-          编辑
-        </KunButton>
+        <div class="flex items-center gap-2">
+          <KunButton
+            v-if="isCreator(todo) && !canEditUpdateLog && todo.status === 0"
+            variant="flat"
+            size="sm"
+            color="danger"
+            @click="discardTodo(todo)"
+          >
+            废弃
+          </KunButton>
+
+          <KunButton
+            v-if="isCreator(todo) && todo.status < 2"
+            variant="flat"
+            size="sm"
+            @click="openEditTodoModal(todo)"
+          >
+            编辑
+          </KunButton>
+
+          <KunButton
+            v-if="canEditUpdateLog && todo.status === 0"
+            size="sm"
+            color="primary"
+            @click="claimTodo(todo)"
+          >
+            认领此任务
+          </KunButton>
+
+          <template v-if="isClaimer(todo) && todo.status === 1">
+            <KunButton size="sm" color="primary" @click="completeTodo(todo)">
+              完成
+            </KunButton>
+            <KunButton size="sm" color="danger" @click="discardTodo(todo)">
+              废弃
+            </KunButton>
+          </template>
+        </div>
       </div>
     </KunCard>
 

--- a/apps/web/app/components/update/TodoModal.vue
+++ b/apps/web/app/components/update/TodoModal.vue
@@ -4,7 +4,7 @@ import {
   kunTodoTypeOptions
 } from '~/constants/update'
 import { createTodoSchema, updateTodoSchema } from '~/validations/todo'
-import type { UpdateTodoPayload } from './types'
+import type { TodoSubmitPayload, UpdateTodoPayload } from './types'
 
 const props = defineProps<{
   modelValue: boolean
@@ -13,7 +13,7 @@ const props = defineProps<{
 
 const emits = defineEmits<{
   'update:modelValue': [value: boolean]
-  submit: [data: UpdateTodoPayload]
+  submit: [data: TodoSubmitPayload]
 }>()
 
 const isModalOpen = computed({
@@ -31,7 +31,14 @@ const todoStatusOptions = Object.entries(KUN_UPDATE_LOG_STATUS_MAP).map(
   })
 )
 
-const getInitialFormData = (): UpdateTodoPayload => ({
+interface TodoFormData {
+  todo_id: number
+  status: number
+  type: string
+  content: string
+}
+
+const getInitialFormData = (): TodoFormData => ({
   todo_id: 0,
   type: 'forum',
   status: 0,
@@ -39,7 +46,7 @@ const getInitialFormData = (): UpdateTodoPayload => ({
   ...(props.initialData || {})
 })
 
-const formData = reactive<UpdateTodoPayload>(getInitialFormData())
+const formData = reactive<TodoFormData>(getInitialFormData())
 
 watch(
   () => isModalOpen.value,
@@ -64,7 +71,10 @@ const handleSubmit = () => {
     return
   }
 
-  emits('submit', { todo_id: formData.todo_id, ...result.data })
+  emits('submit', {
+    todo_id: formData.todo_id,
+    ...result.data
+  } as TodoSubmitPayload)
   isSubmitting.value = false
   isModalOpen.value = false
 }
@@ -78,11 +88,12 @@ const handleSubmit = () => {
   >
     <form @submit.prevent>
       <h2 class="mb-6 text-xl font-bold">
-        {{ isEditing ? '编辑更新日志' : '创建新更新日志' }}
+        {{ isEditing ? '编辑待办' : '创建新待办' }}
       </h2>
 
       <div class="space-y-4">
         <KunSelect
+          v-if="!isEditing"
           v-model="formData.status"
           :options="todoStatusOptions"
           label="待办状态"

--- a/apps/web/app/components/update/types.d.ts
+++ b/apps/web/app/components/update/types.d.ts
@@ -1,6 +1,12 @@
 import type { z } from 'zod'
 import type { updateUpdateLogSchema } from '~/validations/update-log'
-import type { updateTodoSchema } from '~/validations/todo'
+import type { createTodoSchema, updateTodoSchema } from '~/validations/todo'
 
 type UpdateUpdateLogPayload = z.infer<typeof updateUpdateLogSchema>
+type CreateTodoPayload = z.infer<typeof createTodoSchema>
 type UpdateTodoPayload = z.infer<typeof updateTodoSchema>
+type TodoSubmitPayload = Partial<CreateTodoPayload> &
+  Partial<UpdateTodoPayload> & {
+    type: CreateTodoPayload['type']
+    content: string
+  }

--- a/apps/web/app/pages/update.vue
+++ b/apps/web/app/pages/update.vue
@@ -1,24 +1,25 @@
 <script setup lang="ts">
+import { useMediaQuery } from '@vueuse/core'
 import { kunUpdateLogTabItem } from '~/constants/update'
 
 const activeTab = computed(
   () => useRoute().fullPath.split('/').pop() || 'history'
 )
+
+const isMobile = useMediaQuery('(max-width: 640px)')
+const tabOrientation = computed(() =>
+  isMobile.value ? 'horizontal' : 'vertical'
+)
 </script>
 
 <template>
   <div class="space-y-3">
-    <KunHeader
-      name="更新日志"
-      description="鲲 Galgame 论坛的更新历史与开发待办，记录每一次迭代与计划。"
-    />
-
     <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
       <div class="shrink-0 sm:w-32">
         <KunTab
           :items="kunUpdateLogTabItem"
           :model-value="activeTab"
-          orientation="vertical"
+          :orientation="tabOrientation"
           variant="underlined"
           color="primary"
           full-width

--- a/apps/web/app/pages/update/index.vue
+++ b/apps/web/app/pages/update/index.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+definePageMeta({
+  redirect: '/update/todo'
+})
+</script>
+
+<template>
+  <div />
+</template>

--- a/apps/web/app/validations/todo.ts
+++ b/apps/web/app/validations/todo.ts
@@ -7,8 +7,8 @@ export const createTodoSchema = z.object({
   content: z.string().max(1000, '待办最多 1000 个字符').optional().default('')
 })
 
-export const updateTodoSchema = createTodoSchema.merge(
-  z.object({
-    todo_id: z.coerce.number<number>().min(1).max(9999999)
-  })
-)
+export const updateTodoSchema = z.object({
+  todo_id: z.coerce.number<number>().min(1).max(9999999),
+  type: z.enum(KUN_TODO_TYPE_CONST),
+  content: z.string().max(1000, '待办最多 1000 个字符').optional().default('')
+})

--- a/apps/web/shared/types/update-log.ts
+++ b/apps/web/shared/types/update-log.ts
@@ -17,6 +17,9 @@ export interface UpdateTodo {
   content: string
   completed_time: Date | string | null
   user_id: number
+  user: KunUser
+  claimed_user_id: number | null
+  claimed_user?: KunUser | null
   created: Date | string
   updated: Date | string
 }


### PR DESCRIPTION
## 概述 / Summary

将「待办列表」从一个静态只读列表改造成完整的任务看板：条目可被**认领 / 完成 / 废弃**，并显示发布者信息。

Turn `/update/todo` from a static read-only list into a full task board: entries can be **claimed / completed / discarded**, and each shows its publisher.

## 问题 / Bug

1. **待办页缺少任务管理**：只能看不能操作，没有认领/完成/废弃流程，也不显示发布者。
   The todo page had no task management — no claim/complete/discard flow and no publisher info.

2. **`/update` 是空白页**：父级路由没有 `index` 页面，正文区为空。
   `/update` was an empty shell — the parent route had no index page.

3. **首页「其他」分类跳转到空白页**：feed 触发器把待办/更新日志的链接硬编码成 `/update`。
   The home "others" feed linked todo/update_log cards to `/update`, an empty page.

4. **页面有两个 `h1`**：父级 `update.vue` 和子页面都渲染了 `KunHeader`（默认 h1）。
   Duplicate `h1` — both the parent page and the child pages rendered `KunHeader` (default h1).

## 原因 / Cause

1. `todo` 表缺少认领者字段，后端也没有状态流转接口。
   The `todo` table had no claimer column, and the API had no state-transition endpoints.

2. `pages/update/` 下没有 `index.vue`。
   No `index.vue` existed under `pages/update/`.

3. `feed_sync_todo` / `feed_sync_update_log` 触发器把 link 写死为 `/update`（迁移 034/074 遗留）。
   The feed triggers hard-coded `/update` (left over from migrations 034/074).

4. 父子路由都渲染 `KunHeader`，默认 `scale="h1"`。
   Both parent and child routes rendered `KunHeader` at the default `h1` scale.

## 解决方式 / Solution

1. **任务看板状态机**：新增 `todo.claimed_user_id` 字段（迁移 075），新增 `claim` / `complete` / `discard` 接口与前端按钮。权限规则：
   - 发起者（无编辑权限）：可编辑内容（不含状态）、可废弃「待处理」条目；
   - 有 `update_log.edit` 的用户：可认领「待处理」条目（→ 进行中，显示「已被 X 认领」）；
   - 认领者：可完成（→ 已完成）或废弃（→ 已废弃）。
   **Task-board state machine**: add `todo.claimed_user_id` (migration 075), plus `claim` / `complete` / `discard` endpoints and buttons. Rules: creator can edit content or discard a pending entry; `update_log.edit` holders can claim a pending entry; only the claimer can complete or discard an in-progress entry.

2. **`/update` 重定向**：新增 `pages/update/index.vue`，将 `/update` 重定向到 `/update/todo`。
   **Redirect**: add `pages/update/index.vue` redirecting `/update` → `/update/todo`.

3. **修正 feed 链接**：迁移 076 把触发器链接改为 `/update/todo`（todo）与 `/update/history`（更新日志），并回填已有数据。
   **Fix feed links**: migration 076 points the triggers at `/update/todo` and `/update/history` and backfills existing rows.

4. **唯一 h1**：删除父级 `KunHeader`，子页面各自持有唯一 `h1`。
   **Single h1**: remove the parent `KunHeader`; each child page owns its `h1`.

## 其它 / Other

- 「创建待办」按钮对所有登录用户开放（后端不再要求 `update_log.create`）。
  The "create todo" button is open to all logged-in users (no `update_log.create` required).
- 发布者头像/昵称可点击进入个人主页。
  The publisher's avatar/name links to their profile.
- 手机端「更新历史 / 待办列表」tab 改为横向。
  The update tab is horizontal on mobile.

## 迁移 / Migrations

- `075_todo_claimed_user`：`todo` 表新增 `claimed_user_id`。
- `076_feed_update_links`：修正 `feed_sync_todo` / `feed_sync_update_log` 的 link。
