### PR TITLE
feat: VNDB play time display + allow editors to complete todos

### DIFF
--- a/apps/api/internal/galgame/client/catalog_detail.go
+++ b/apps/api/internal/galgame/client/catalog_detail.go
@@ -53,6 +53,7 @@ func CatalogDetailToFull(ctx context.Context, d *catWorkDetail, gid int) dto.Nex
 	}
 
 	f.ExternalRatings = catalogExternalRatings(d.Ratings)
+	f.Playtimes = catalogPlaytimes(d.Playtimes)
 
 	labelAt := make(map[int64]int, len(d.Labels))
 	for _, l := range d.Labels {
@@ -150,6 +151,19 @@ func catalogExternalRatings(rows []catRating) []dto.GalgameExternalRating {
 			Source: r.Source, Score: r.Score, VoteCount: r.VoteCount, Rank: r.Rank,
 			Distribution: catalogRatingBuckets(r.Distribution),
 			Stats:        catalogRatingStats(r.Stats),
+		})
+	}
+	return out
+}
+
+func catalogPlaytimes(rows []catPlaytime) []dto.NextMoeGalgamePlaytime {
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]dto.NextMoeGalgamePlaytime, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, dto.NextMoeGalgamePlaytime{
+			Source: r.Source, Minutes: r.Minutes, VoteCount: r.VoteCount,
 		})
 	}
 	return out

--- a/apps/api/internal/galgame/client/catalog_detail_test.go
+++ b/apps/api/internal/galgame/client/catalog_detail_test.go
@@ -365,3 +365,23 @@ func TestCatalogDetail_ImagesCarryTheirSource(t *testing.T) {
 		t.Errorf("screenshot sources = %+v, want vndb then getchu", f.Screenshots)
 	}
 }
+
+func TestCatalogDetail_PlaytimesCarryTheirSource(t *testing.T) {
+	body := `{"id":4242,"display_name":"Kun","content_rating":"all_ages","olang":"ja","playtimes":[
+		{"source":"vndb","minutes":384,"vote_count":39},
+		{"source":"erogamescape","minutes":240,"vote_count":0}
+	]}`
+	f := fullOf(t, body)
+
+	if len(f.Playtimes) != 2 {
+		t.Fatalf("len = %d, want 2", len(f.Playtimes))
+	}
+	vndb := f.Playtimes[0]
+	if vndb.Source != "vndb" || vndb.Minutes != 384 || vndb.VoteCount != 39 {
+		t.Errorf("vndb playtime = %+v, want source vndb 384 minutes 39 votes", vndb)
+	}
+	egs := f.Playtimes[1]
+	if egs.Source != "erogamescape" || egs.Minutes != 240 || egs.VoteCount != 0 {
+		t.Errorf("erogamescape playtime = %+v, want source erogamescape 240 minutes 0 votes", egs)
+	}
+}

--- a/apps/api/internal/galgame/client/catalog_face.go
+++ b/apps/api/internal/galgame/client/catalog_face.go
@@ -336,6 +336,7 @@ type catWorkDetail struct {
 	Credits    []catCreditGroup   `json:"credits"`
 	Characters []catWorkCharacter `json:"characters"`
 	Ratings    []catRating        `json:"ratings"`
+	Playtimes  []catPlaytime      `json:"playtimes"`
 }
 
 type catWorkCharacter struct {

--- a/apps/api/internal/galgame/client/catalog_wire.go
+++ b/apps/api/internal/galgame/client/catalog_wire.go
@@ -116,6 +116,12 @@ type catWorkLink struct {
 	URL    string `json:"url"`
 }
 
+type catPlaytime struct {
+	Source    string `json:"source"`
+	Minutes   int    `json:"minutes"`
+	VoteCount int    `json:"vote_count"`
+}
+
 type catRatingBucket struct {
 	Score int `json:"score"`
 	Count int `json:"count"`

--- a/apps/api/internal/galgame/dto/galgame_dto.go
+++ b/apps/api/internal/galgame/dto/galgame_dto.go
@@ -214,6 +214,12 @@ type GalgameExternalRating struct {
 	Stats        *GalgameRatingStats   `json:"stats,omitempty"`
 }
 
+type GalgamePlaytime struct {
+	Source    string `json:"source"`
+	Minutes   int    `json:"minutes"`
+	VoteCount int    `json:"vote_count"`
+}
+
 // GalgameIntro is one language's introduction. The language list is whatever
 // catalog actually carries rather than a fixed set: the four product slots this
 // replaces always shipped an empty 繁體中文, because catalog has never held a
@@ -273,6 +279,7 @@ type GalgameDetail struct {
 	Rating                     float64                  `json:"rating"`
 	RatingCount                int                      `json:"rating_count"`
 	ExternalRatings            []GalgameExternalRating  `json:"external_ratings"`
+	Playtimes                  []GalgamePlaytime        `json:"playtimes"`
 	Refs                       map[string]string        `json:"refs,omitempty"`
 	Created                    string                   `json:"created"`
 	Updated                    string                   `json:"updated"`

--- a/apps/api/internal/galgame/dto/nextmoe_dto.go
+++ b/apps/api/internal/galgame/dto/nextmoe_dto.go
@@ -87,6 +87,12 @@ type NextMoeTagWithSpoiler struct {
 	Tag          NextMoeTag `json:"tag"`
 }
 
+type NextMoeGalgamePlaytime struct {
+	Source    string `json:"source"`
+	Minutes   int    `json:"minutes"`
+	VoteCount int    `json:"vote_count"`
+}
+
 type NextMoeGalgameDetailFull struct {
 	ID                         int                        `json:"id"`
 	VndbID                     string                     `json:"vndb_id"`
@@ -113,6 +119,7 @@ type NextMoeGalgameDetailFull struct {
 	EffectivePortraitHeight    int                        `json:"effective_portrait_height,omitempty"`
 	EffectivePortraitThumbhash string                     `json:"effective_portrait_thumbhash,omitempty"`
 	ExternalRatings            []GalgameExternalRating    `json:"external_ratings"`
+	Playtimes                  []NextMoeGalgamePlaytime   `json:"playtimes"`
 	Covers                     []NextMoeGalgameCover      `json:"covers"`
 	Screenshots                []NextMoeGalgameScreenshot `json:"screenshots"`
 	Alias                      []NextMoeAlias             `json:"alias"`

--- a/apps/api/internal/galgame/service/galgame_mapper.go
+++ b/apps/api/internal/galgame/service/galgame_mapper.go
@@ -91,6 +91,7 @@ func galgameDetailFromNextMoe(g dto.NextMoeGalgameDetailFull, users map[string]d
 		EffectivePortraitHeight:    g.EffectivePortraitHeight,
 		EffectivePortraitThumbhash: g.EffectivePortraitThumbhash,
 		ExternalRatings:            externalRatingsOrEmpty(g.ExternalRatings),
+		Playtimes:                  playtimesOrEmpty(g.Playtimes),
 		Refs:                       g.Refs,
 		Covers:                     coversFromNextMoe(g.Covers),
 		Screenshots:                screenshotsFromNextMoe(g.Screenshots),
@@ -119,6 +120,17 @@ func externalRatingsOrEmpty(rows []dto.GalgameExternalRating) []dto.GalgameExter
 		return []dto.GalgameExternalRating{}
 	}
 	return rows
+}
+
+func playtimesOrEmpty(rows []dto.NextMoeGalgamePlaytime) []dto.GalgamePlaytime {
+	if rows == nil {
+		return []dto.GalgamePlaytime{}
+	}
+	out := make([]dto.GalgamePlaytime, len(rows))
+	for i, r := range rows {
+		out[i] = dto.GalgamePlaytime{Source: r.Source, Minutes: r.Minutes, VoteCount: r.VoteCount}
+	}
+	return out
 }
 
 func coversFromNextMoe(rows []dto.NextMoeGalgameCover) []dto.GalgameCover {

--- a/apps/api/internal/update/handler/update_handler.go
+++ b/apps/api/internal/update/handler/update_handler.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 
 	"kun-galgame-api/pkg/errors"
+	"kun-galgame-api/pkg/perm"
 	"kun-galgame-api/pkg/response"
 	"kun-galgame-api/pkg/userclient"
 	"kun-galgame-api/pkg/utils"
@@ -270,7 +271,8 @@ func (h *UpdateHandler) CompleteTodo(c fiber.Ctx) error {
 	if todo.Status != adminModel.TodoStatusClaimed {
 		return response.Error(c, errors.ErrForbidden("该待办未处于进行中状态"))
 	}
-	if todo.ClaimedUserID == nil || *todo.ClaimedUserID != user.ID {
+	isClaimer := todo.ClaimedUserID != nil && *todo.ClaimedUserID == user.ID
+	if !isClaimer && !perm.CanUser(user.ID, user.Roles, perm.UpdateLogEdit) {
 		return response.Error(c, errors.ErrForbidden("只有认领者可以完成该待办"))
 	}
 	moved, err := h.repo.CompleteTodo(req.TodoID, user.ID)

--- a/apps/web/app/components/galgame/Header.vue
+++ b/apps/web/app/components/galgame/Header.vue
@@ -69,6 +69,23 @@ const openRatingDetail = (source: string) => {
 
 const coversOpen = ref(false)
 const hasMoreCovers = computed(() => (props.galgame.covers?.length ?? 0) > 1)
+
+const vndbPlaytime = computed(() =>
+  props.galgame.playtimes?.find((p) => p.source === 'vndb')
+)
+
+const vndbPlaytimeText = computed(() => {
+  const minutes = vndbPlaytime.value?.minutes
+  if (!minutes || minutes <= 0) {
+    return ''
+  }
+  const hours = Math.floor(minutes / 60)
+  const rest = minutes % 60
+  if (hours <= 0) {
+    return `${rest} 分钟`
+  }
+  return rest > 0 ? `${hours} 小时 ${rest} 分钟` : `${hours} 小时`
+})
 </script>
 
 <template>
@@ -189,6 +206,17 @@ const hasMoreCovers = computed(() => (props.galgame.covers?.length ?? 0) > 1)
           @open-rating="isRatingOpen = true"
           @open-detail="openRatingDetail"
         />
+
+        <div
+          v-if="vndbPlaytimeText"
+          class="text-default-600 flex items-center gap-2 text-sm"
+        >
+          <KunIcon name="lucide:clock" />
+          <span>
+            游戏时长：{{ vndbPlaytimeText }}
+            <span class="text-default-400">(来源于VNDB)</span>
+          </span>
+        </div>
 
         <GalgameHeaderRatingModal
           v-model="isRatingDetailOpen"

--- a/apps/web/app/components/update/Todo.vue
+++ b/apps/web/app/components/update/Todo.vue
@@ -259,16 +259,26 @@ const discardTodo = async (todo: UpdateTodo) => {
             认领此任务
           </KunButton>
 
-          <template
-            v-if="isClaimer(todo) && todo.status === KUN_TODO_STATUS.CLAIMED"
+          <KunButton
+            v-if="
+              (isClaimer(todo) || canEditUpdateLog) &&
+              todo.status === KUN_TODO_STATUS.CLAIMED
+            "
+            size="sm"
+            color="primary"
+            @click="completeTodo(todo)"
           >
-            <KunButton size="sm" color="primary" @click="completeTodo(todo)">
-              完成
-            </KunButton>
-            <KunButton size="sm" color="danger" @click="discardTodo(todo)">
-              废弃
-            </KunButton>
-          </template>
+            完成
+          </KunButton>
+
+          <KunButton
+            v-if="isClaimer(todo) && todo.status === KUN_TODO_STATUS.CLAIMED"
+            size="sm"
+            color="danger"
+            @click="discardTodo(todo)"
+          >
+            废弃
+          </KunButton>
         </div>
       </div>
     </KunCard>

--- a/apps/web/shared/types/galgame.ts
+++ b/apps/web/shared/types/galgame.ts
@@ -91,6 +91,12 @@ export interface GalgameExternalRating {
   stats?: GalgameRatingStats
 }
 
+export interface GalgamePlaytime {
+  source: string
+  minutes: number
+  vote_count: number
+}
+
 export interface GalgameIntro {
   lang: string
   intro: string
@@ -148,6 +154,7 @@ export interface GalgameDetail {
   rating?: number
   rating_count?: number
   external_ratings?: GalgameExternalRating[]
+  playtimes?: GalgamePlaytime[]
   refs?: Record<string, string>
   created: Date | string
   updated: Date | string


### PR DESCRIPTION
## Summary / 概述

This PR bundles two changes and their prerequisite feature:

1. **Todo task board (prerequisite)** — claim / complete / discard flow with `todo.claimed_user_id`.
2. **Bug fix**: the in-progress todo's "完成" (Complete) button was only shown to the claimer; now every user with the `update_log.edit` permission can also complete it.
3. **Feature**: display the VNDB play time on the galgame detail header (游戏时长, sourced from VNDB).

## Bug / 问题

When a todo is in progress (`status === 1`), the "完成" button was gated solely on `isClaimer(todo)` on the frontend, and the backend `CompleteTodo` handler rejected anyone except `ClaimedUserID`. An editor holding the `update_log.edit` permission — who is otherwise allowed to manage the board — saw no way to mark a task as completed.

当待办处于进行中（`status === 1`）时，前端「完成」按钮的显示条件只判断了 `isClaimer(todo)`，后端 `CompleteTodo` 也只允许 `ClaimedUserID` 本人操作。拥有 `update_log.edit` 权限、本可以管理看板的编辑者，却看不到任何完成该任务的操作入口。

## Root cause / 问题原因

- Frontend: `Todo.vue` wrapped the button in `v-if="isClaimer(todo) && todo.status === 1"`.
- Backend: `CompleteTodo` returned `403 只有认领者可以完成该待办` unless `ClaimedUserID == user.ID`.

- 前端：`Todo.vue` 用 `v-if="isClaimer(todo) && todo.status === 1"` 包裹按钮。
- 后端：`CompleteTodo` 在 `ClaimedUserID != user.ID` 时返回 `403 只有认领者可以完成该待办`。

## Solution / 解决方式

- Frontend: show the "完成" button when `(isClaimer(todo) || canEditUpdateLog) && todo.status === 1`; the "废弃" button stays claimer-only.
- Backend: allow completion when the requester is the claimer **or** has `perm.UpdateLogEdit` (`perm.CanUser(user.ID, user.Roles, perm.UpdateLogEdit)`).

- 前端：「完成」按钮改为 `(isClaimer(todo) || canEditUpdateLog) && todo.status === 1` 时显示；「废弃」按钮保持仅认领者可见。
- 后端：请求者是认领者 **或** 拥有 `perm.UpdateLogEdit`（`perm.CanUser(user.ID, user.Roles, perm.UpdateLogEdit)`）时允许完成。

## Play time feature / 游戏时长功能

The catalog detail endpoint already returns `playtimes` (`[{source, minutes, vote_count}]`). We thread it through the Go client (`catPlaytime`), DTOs (`NextMoeGalgamePlaytime`, `GalgamePlaytime`) and mapper, then render `游戏时长：X 小时 Y 分钟（来源于VNDB）` between the rating strip and the like/favorite actions, only when a VNDB play time entry exists.

目录详情接口已返回 `playtimes`（`[{source, minutes, vote_count}]`）。我们把它贯通 Go 客户端（`catPlaytime`）、DTO（`NextMoeGalgamePlaytime`、`GalgamePlaytime`）与 mapper，并在评分栏与点赞/收藏之间渲染 `游戏时长：X 小时 Y 分钟（来源于VNDB）`，仅在存在 VNDB 游玩时长条目时显示。
